### PR TITLE
Find the condor installation that is first in path by searching for cond...

### DIFF
--- a/src/condor_ce_job_router_info
+++ b/src/condor_ce_job_router_info
@@ -1,19 +1,23 @@
 #!/bin/sh
 
+missing_tool()
+{
+    echo 'Could not find Job Router diagnostic tool. Please verify your HTCondor installation.'
+    exit 1
+}
+
 . /usr/share/condor-ce/condor_ce_env_bootstrap
 . /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
-which condor_job_router_info &> /dev/null
-if [[ $? -eq 0 ]]; then
-    exec condor_job_router_info "$@"
+CONDOR_BIN_DIR=$(/usr/bin/dirname $(/usr/bin/which condor_version 2> /dev/null ) 2> /dev/null ) 
+if [ -z "$CONDOR_BIN_DIR" ]; then
+    missing_tool
+elif [ -x "$CONDOR_BIN_DIR/condor_job_router_info" ]; then
+    exec "$CONDOR_BIN_DIR/condor_job_router_info" "$@"
+elif [ -x "$CONDOR_BIN_DIR/condor_job_router_tool" ]; then
+    exec "$CONDOR_BIN_DIR/condor_job_router_tool" "$@"
 else
-    which condor_job_router_tool &> /dev/null
-    if [[ $? -eq 0 ]]; then
-        exec condor_job_router_tool "$@"
-    else
-        echo 'Could not find Job Router diagnostic tool. Please verify your HTCondor installation.'
-        exit 1
-    fi
+    missing_tool
 fi 
 
 


### PR DESCRIPTION
...or_version and then determine whether to use the _info or _tool versions of the Job Router diagnostic tool. Remove bashisms.