### PR TITLE
Fix usage message to tell the user to use --pool

### DIFF
--- a/src/condor_ce_info_status
+++ b/src/condor_ce_info_status
@@ -144,7 +144,7 @@ def parseOpts(argv):
     Returns the options and the address of the collector to contact
 
     """
-    usage = "%prog [options] [<collector hostname>[:port]]"
+    usage = "%prog [options] [--pool=<collector addr>[:<port>]]"
     epilog = '''
 
 Here are some example queries.


### PR DESCRIPTION
since plain putting the collector as a positional argument doesn't work, you must use --pool instead