### PR TITLE
Fix for SW-1782 (--vo broken if missing in condor_ce_info_status)

### DIFF
--- a/src/condor_ce_info_query.py
+++ b/src/condor_ce_info_query.py
@@ -102,7 +102,11 @@ def filterResourceAds(constraints, resources):
 
     """
     predicates = []
-    for attr in constraints:
+    for attr, value in constraints.iteritems():
+        if value is None:
+            continue
+        # NB: Do not use 'attr' or 'value' inside the lambdas because that
+        # would be 'closing over the loop variable'
         if attr == 'cpus':
             predicates.append(
                 lambda res: constraints['cpus'] <= res['CPUs'])


### PR DESCRIPTION
If --vo was unspecified, the script would add a constraint against the
VO 'None'.  This fixes it.

I also tried to make some tweaks in filterResourceAds to reduce
duplication, but after they failed, I added a comment with an
explanation of why the duplication is necessary.