### PR TITLE
Fix malformed pilot regex

### DIFF
--- a/config/condor_mapfile
+++ b/config/condor_mapfile
@@ -1,6 +1,6 @@
 GSI "^\/DC\=com\/DC\=DigiCert-Grid\/O=Open Science Grid\/OU\=Services\/CN\=(host\/)?([A-Za-z0-9.\-]*)$" \2@daemon.opensciencegrid.org
 GSI "^\/DC\=DigiCert-Grid\/DC\=com\/O=Open Science Grid\/OU\=Services\/CN\=(host\/)?([A-Za-z0-9.\-]*)$" \2@daemon.opensciencegrid.org
 GSI (.*) GSS_ASSIST_GRIDMAP
-GSI (/CN=[-.A-Za-z0-9/= ]+) \1@unmapped.opensciencegrid.org
+GSI "(/CN=[-.A-Za-z0-9/= ]+)" \1@unmapped.opensciencegrid.org
 CLAIMTOBE .* anonymous@claimtobe
 FS (.*) \1


### PR DESCRIPTION
So the field separator appears to be ' ' in the CERTIFICATE_MAPFILE so I wrapped the entire regex in quotes. Tried it on my CE and it looks like it was able to parse it:

> 03/27/15 10:13:02 MapFile: Canonicalization File: method='gsi' principal='(/CN=[-.A-Za-z0-9/= ]+)' canonicalization='\1@unmapped.opensciencegrid.org'