### PR TITLE
Fail to start the HTCondor CE if the syntax of JOB_ROUTER_DEFAULTS or

### DIFF
--- a/src/condor-ce
+++ b/src/condor-ce
@@ -48,6 +48,16 @@ fi
 
 start() {
     echo -n $"Starting Condor-CE daemons: "
+
+    # Check validity of job router knobs
+    for ATTR in 'JOB_ROUTER_DEFAULTS' 'JOB_ROUTER_ENTRIES'; do
+        python -c "import htcondor; import classad; classad.ExprTree(htcondor.param[\"$ATTR\"])" &> /dev/null
+        if [ $? -ne 0 ]; then
+            echo "Could not read $ATTR in the HTCondor CE configuration. Please verify syntax correctness."
+            exit 6
+        fi
+    done
+
     daemon --pidfile $pidfile --check $prog /usr/share/condor-ce/condor_ce_startup -pidfile $pidfile
     RETVAL=$?
     echo


### PR DESCRIPTION
JOB_ROUTER_ENTRIES is incorrect