### PR TITLE
Add COLLECTOR_REQUIREMENTS expression to ce-collector config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ install(PROGRAMS src/condor_ce_config_generator src/condor_ce_config_val src/con
 install(FILES src/condor_ce_info_query.py src/condor_ce_tools.py DESTINATION ${PYTHON_SITELIB})
 
 install(FILES config/condor_config config/condor_mapfile DESTINATION ${SYSCONF_INSTALL_DIR}/condor-ce)
-install(FILES config/01-ce-collector.conf config/02-ce-auth-generated.conf config/01-ce-auth.conf config/01-common-auth.conf config/01-ce-router.conf config/02-ce-condor.conf config/02-ce-pbs.conf config/02-ce-lsf.conf config/02-ce-sge.conf config/03-ce-shared-port.conf config/03-managed-fork.conf DESTINATION ${SYSCONF_INSTALL_DIR}/condor-ce/config.d)
+install(FILES config/01-ce-collector.conf config/01-ce-collector-requirements.conf config/02-ce-auth-generated.conf config/01-ce-auth.conf config/01-common-auth.conf config/01-ce-router.conf config/02-ce-condor.conf config/02-ce-pbs.conf config/02-ce-lsf.conf config/02-ce-sge.conf config/03-ce-shared-port.conf config/03-managed-fork.conf DESTINATION ${SYSCONF_INSTALL_DIR}/condor-ce/config.d)
 install(FILES config/01-ce-collector-defaults.conf config/01-ce-auth-defaults.conf config/01-common-auth-defaults.conf config/01-common-collector-defaults.conf config/01-ce-info-services-defaults.conf config/01-ce-router-defaults.conf config/02-ce-condor-defaults.conf config/02-ce-pbs-defaults.conf config/02-ce-lsf-defaults.conf config/02-ce-sge-defaults.conf config/03-ce-shared-port-defaults.conf config/03-managed-fork-defaults.conf DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce/config.d)
 install(FILES config/ce-status.cpf DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce)
 install(FILES config/99-condor-ce.conf config/50-condor-ce-defaults.conf DESTINATION ${SYSCONF_INSTALL_DIR}/condor/config.d)

--- a/config/01-ce-collector-requirements.conf
+++ b/config/01-ce-collector-requirements.conf
@@ -1,0 +1,48 @@
+
+###############################################################################
+#
+# HTCondor-CE collector requirements configuration file.
+#
+# This file will not be overwritten on RPM upgrade.  This should contain
+# a reasonable expression for OSG production.
+#
+###############################################################################
+
+# The COLLECTOR_REQUIREMENTS expressions require that CE ads (ad type is
+# Scheduler), xrootd startd ads (ad type is Machine) and xrootd master ads
+# (ad type is DaemonMaster) have:
+# - AuthenticatedIdentity attr that end in @daemon.opensciencegrid.org
+# - Name attrs that match the AuthenticatedIdentity attr
+
+# COLLECTOR_REQUIREMENTS subexpression for CE ad
+# For a CE ad, the grid_resource must also match Name and AuthenticatedIdentity
+# e.g. for this:
+# - AuthenticatedIdentity == "ce.example.net@daemon.opensciencegrid.org"
+# you need this:
+# - grid_resource == "condor ce.example.net ce.example.net:XXXX" (port doesn't
+#   matter for collector address part, and may be absent)
+COLLECTOR_REQUIREMENTS = \
+  (  (TARGET.MyType == "Scheduler") \
+  && (strcat(TARGET.Name, "@daemon.opensciencegrid.org") == string(TARGET.AuthenticatedIdentity))  \
+  && (isString(TARGET.grid_resource))  \
+  && (stringListSize(TARGET.grid_resource, ": ") >= 3)  \
+  && (split(TARGET.grid_resource, ": ")[1] == splitUserName(TARGET.AuthenticatedIdentity)[0]) \
+  && (split(TARGET.grid_resource, ": ")[2] == splitUserName(TARGET.AuthenticatedIdentity)[0]) \
+  )
+
+# COLLECTOR_REQUIREMENTS subexpression for xrootd startd ad
+COLLECTOR_REQUIREMENTS = $(COLLECTOR_REQUIREMENTS) || \
+ (  (TARGET.MyType == "Machine") \
+ && (strcat(TARGET.Name, "@daemon.opensciencegrid.org") == strcat("xrootd@", TARGET.AuthenticatedIdentity)) \
+ )
+
+# COLLECTOR_REQUIREMENTS subexpression for xrootd master ad
+COLLECTOR_REQUIREMENTS = $(COLLECTOR_REQUIREMENTS) || \
+ (  (TARGET.MyType == "DaemonMaster") \
+ && (strcat(TARGET.Name, "@daemon.opensciencegrid.org") == string(TARGET.AuthenticatedIdentity)) \
+ )
+
+# Accept other ads
+COLLECTOR_REQUIREMENTS = $(COLLECTOR_REQUIREMENTS) || \
+ ((TARGET.MyType != "Scheduler") && (TARGET.MyType != "Machine") && (TARGET.MyType != "DaemonMaster"))
+


### PR DESCRIPTION
This expression keeps rogue sites from being able to send CE ads, or
xrootd startd/master ads for other sites.  This should get rid of the
need for a whitelist of sites that can send ads.

This is for SOFTWARE-1790 / SOFTWARE-1820.