### PR TITLE
Fix condor_ce_run without the '-r' option (SOFTWARE-1910)

### DIFF
--- a/src/condor_ce_run
+++ b/src/condor_ce_run
@@ -131,10 +131,10 @@ def submit_job(job_info):
 
     if rc < 0:
         raise ce.CondorRunException("Failed to submit job; condor_submit " \
-                                    "terminated with signal %d." % -rc)
+                                    "terminated with signal %d.\nSTDOUT: %s\n STDERR: %s" % (-rc, stdout, stderr))
     elif rc > 0:
         raise ce.CondorRunException("Failed to submit job; condor_submit " \
-                                    "exited with code %d. STDOUT: %s\n STDERR: %s" % (rc, stdout, stderr))
+                                    "exited with code %d.\nSTDOUT: %s\n STDERR: %s" % (rc, stdout, stderr))
 
 def wait_for_job(job_info):
     if job_info['remote']:

--- a/src/condor_ce_run
+++ b/src/condor_ce_run
@@ -8,8 +8,6 @@ import socket
 import optparse
 import traceback
 
-os.environ.setdefault("CONDOR_CONFIG", "/etc/condor-ce/condor_config")
-
 import htcondor
 import condor_ce_tools as ce
 
@@ -220,6 +218,8 @@ def configureAuth():
 
 def main():
     opts, args = parse_opts()
+    if opts.remote:
+        os.environ.setdefault("CONDOR_CONFIG", "/etc/condor-ce/condor_config")
     configureAuth()
 
     if len(args) < 2:


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-1910

Do not utilize the CE config when submitting a job with condor_ce_run
without the -r option (SOFTWARE-1910). When the CE config was used, a
grid universe job would be submitted to the HTCondor CE queue, which by
default puts grid universe jobs on hold.