### PR TITLE
Add default_remote_cerequirements

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -56,10 +56,11 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     eval_set_remote_SMPGranularity = ifThenElse(InputRSL.xcount isnt null, InputRSL.xcount, ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1))); \\
     eval_set_remote_NodeNumber = ifThenElse(InputRSL.xcount isnt null, InputRSL.xcount, ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1))); \\
     /* If remote_cerequirements is a string, BLAH will parse it as an expression before examining it */ \\
-    eval_set_remote_cerequirements = ifThenElse(InputRSL.maxWallTime isnt null, strcat("Walltime == ", string(60*InputRSL.maxWallTime), " && CondorCE == 1"), \\
+    eval_set_remote_cerequirements = strcat(ifThenElse(default_remote_cerequirements isnt null, strcat(string(default_remote_cerequirements), " && "), ""), \\
+      ifThenElse(InputRSL.maxWallTime isnt null, strcat("Walltime == ", string(60*InputRSL.maxWallTime), " && CondorCE == 1"), \\
         ifThenElse(maxWallTime isnt null, strcat("Walltime == ", string(60*maxWallTime), " && CondorCE == 1"), \\
           ifThenElse(default_maxWallTime isnt null, strcat("Walltime == ", string(60*default_maxWallTime), " && CondorCE == 1"), \\
-            "CondorCE == 1"))); \\
+            "CondorCE == 1")))); \\
     copy_OnExitHold = "orig_OnExitHold"; \\
     eval_set_OnExitHold = ifThenElse(orig_OnExitHold isnt null, orig_OnExitHold, false) || ifThenElse(minWalltime isnt null && RemoteWallClockTime isnt null, RemoteWallClockTime < 60*minWallTime, false); \\
     copy_OnExitHoldReason = "orig_OnExitHoldReason"; \\


### PR DESCRIPTION
Add default_remote_cerequirements.  This enables the administrator to
specify routes with the attribute default_remote_cerequirements, which
will then be appended to the remote_cerequirements.  Therefore, to add
a new type of resource (such as a gpu), the admin needs to:

1. Add to the default_remote_cerequirements in the router entry so
that the local submit file (.sh) can pick up the new requirement.  For
a GPU, it would be:

```
set_default_remote_cerequirements = "RequestGpus == 1"; \
```

2. Add to the [pbs|lsf|sge|…]_local_submit_attributes.sh an if
statement to capture and use this attribute.  Again, for a GPU and
Slurm:

```
if [ -n "$RequestGpus" ]; then
    echo "#SBATCH --gres=gpu:$RequestGpus"
    echo "module load cuda/6.0"
fi
```