### PR TITLE
Use default client auth methods (i.e., don't add GSI) when running

### DIFF
--- a/src/condor_ce_run
+++ b/src/condor_ce_run
@@ -220,7 +220,7 @@ def main():
     opts, args = parse_opts()
     if opts.remote:
         os.environ.setdefault("CONDOR_CONFIG", "/etc/condor-ce/condor_config")
-    configureAuth()
+        configureAuth()
 
     if len(args) < 2:
         print "Usage: condor_ce_run <hostname> <command> [arg1] [arg2] [...]"


### PR DESCRIPTION
condor_ce_run without '-r' (SOFTWARE-1910)