### PR TITLE
Record absent ads in the collector.

### DIFF
--- a/config/01-ce-collector-defaults.conf
+++ b/config/01-ce-collector-defaults.conf
@@ -10,3 +10,15 @@
 
 DAEMON_LIST = MASTER COLLECTOR
 
+# If a CE drops offline, we don't want to remove its ad from the collector.
+ABSENT_REQUIREMENTS = (MyType=?="Scheduler")
+
+# Even missing CEs expire after 7 days
+ABSENT_EXPIRE_ADS_AFTER = 7*86400
+
+# When the CE is turned off (for downtimes for example), keep the ad
+EXPIRE_INVALIDATED_ADS = true
+
+COLLECTOR_PERSISTENT_AD_LOG = $(SPOOL)/collector_ads.log
+VALID_SPOOL_FILES=collector_ads.log $(VALID_SPOOL_FILES)
+


### PR DESCRIPTION
If a CE drops offline, cache their ads centrally for awhile.