### PR TITLE
Fix evaluation of UID and extattr tables (SOFTWARE-2067)

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -70,8 +70,8 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     copy_OnExitHoldSubCode = "orig_OnExitHoldSubCode"; \\
     eval_set_OnExitHoldSubCode = ifThenElse((orig_OnExitHold isnt null) && orig_OnExitHold, \\
         ifThenElse(orig_OnExitHoldSubCode isnt null, orig_OnExitHoldSubCode, 1), 42); \\
-    eval_set_AccountingGroupOSG = @accounting_group@; \\
-    set_AccountingGroup = AccountingGroupOSG; \\
+    set_AccountingGroupOSG = @accounting_group@; \\
+    eval_set_AccountingGroup = AccountingGroupOSG; \\
   ]
 """
 


### PR DESCRIPTION
Since eval_set_* happens after set_*, we need to switch how we set AccountingGroup and AccountingGroupOSG