### PR TITLE
Enable GSI map caching to decrease the number of GSI callouts

### DIFF
--- a/config/01-ce-auth-defaults.conf
+++ b/config/01-ce-auth-defaults.conf
@@ -43,6 +43,7 @@ SCHEDD.SEC_DAEMON_AUTHENTICATION_METHODS = FS,GSI
 # GSI settings
 GSI_DAEMON_CERT = /etc/grid-security/hostcert.pem
 GSI_DAEMON_KEY  = /etc/grid-security/hostkey.pem
+GSS_ASSIST_GRIDMAP_CACHE_EXPIRATION = 30*$(MINUTE)
 
 # Enable the audit log for the CE's activities
 SCHEDD_AUDIT_LOG = $(LOG)/AuditLog

--- a/config/01-ce-auth.conf
+++ b/config/01-ce-auth.conf
@@ -46,6 +46,7 @@ SCHEDD.SEC_DAEMON_AUTHENTICATION_METHODS = FS,GSI
 # GSI settings
 GSI_DAEMON_CERT = /etc/grid-security/hostcert.pem
 GSI_DAEMON_KEY  = /etc/grid-security/hostkey.pem
+GSS_ASSIST_GRIDMAP_CACHE_EXPIRATION = 30*$(MINUTE)
 
 # Enable the audit log for the CE's activities
 SCHEDD_AUDIT_LOG = $(LOG)/AuditLog


### PR DESCRIPTION
Due to a memory leak in lcmaps, we'd like to make fewer GSI authentication callouts.