### PR TITLE
Use SHUTDOWN_FAST_TIMEOUT to kill the ce-view after 10 seconds.

### DIFF
--- a/config/05-ce-view-defaults.conf
+++ b/config/05-ce-view-defaults.conf
@@ -42,6 +42,10 @@ SCHEDD_CRON_CEVIEW_RECONFIG_RERUN = True
 # Do not do security negotiation; this can break CE View when using IP-load-balanced collectors.
 CEVIEW.SEC_CLIENT_NEGOTIATION = NEVER
 
+# Cherrypy does not respect SIGTERM signals from the master, so kill it (and everything else) quickly
+# with SIGKILL signal (9) after waiting 10 seconds
+SHUTDOWN_FAST_TIMEOUT = 10
+
 # If available, run CE View as a DC daemon.
 if version >= 8.3.5
   DC_DAEMON_LIST = +CEVIEW


### PR DESCRIPTION
Cherrypy doesn't respect SIGTERM signals, so we must use the SHUTDOWN_FAST_TIMEOUT
to SIGKILL the ce-view after 10 seconds.