### PR TITLE
Drop all RSL references (SOFTWARE-2205)

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -136,8 +136,6 @@ Group: Applications/System
 Summary: Client-side tools for submission to HTCondor-CE
 
 BuildRequires: boost-devel
-BuildRequires: globus-rsl-devel
-BuildRequires: condor-classads-devel
 BuildRequires: cmake
 
 # Note the strange requirements (base package is not required!

--- a/contrib/puppet/osg_ce_condor/files/config.d/01-ce-router.conf
+++ b/contrib/puppet/osg_ce_condor/files/config.d/01-ce-router.conf
@@ -36,7 +36,6 @@ LOCAL_CONFIG_FILE = /usr/share/condor-ce/condor_ce_router_defaults|
 # Only route jobs for an up-to-date client
 # NOTE: disabled because HTCondor-G appears to not set this properly
 #JOB_ROUTER_SOURCE_JOB_CONSTRAINT = ((target.LastClientContact =?= UNDEFINED) || (target.LastClientContact - time() < 30*60)) && (target.CondorCE is True)
-CLASSAD_USER_LIBS = $(LIB)/libeval_rsl.so, $(CLASSAD_USER_LIBS)
 
 # Only route jobs with a valid, non-expired proxy for either the vanilla or standard universe.
 JOB_ROUTER_SOURCE_JOB_CONSTRAINT = (target.x509userproxysubject =!= UNDEFINED) && (target.x509UserProxyExpiration =!= UNDEFINED) && (time() < target.x509UserProxyExpiration) && (target.JobUniverse =?= 5 || target.JobUniverse =?= 1)

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -46,21 +46,20 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     \\
     /* Set new requirements */ \\
     /* set_requirements = LastClientContact - time() < 30*60; */ \\
-    set_requirements = True; \\ %s
+    set_requirements = True; \\
     /* Note default memory request of 2GB */ \\
-    /* Note yet another nested condition allow pass attributes (maxMemory,xcount,jobtype,queue) via gWMS Factory described within ClassAd if undefined via RSL */ \\
-    eval_set_RequestMemory = ifThenElse(InputRSL.maxMemory isnt null, InputRSL.maxMemory, ifThenElse(maxMemory isnt null, maxMemory, ifThenElse(default_maxMemory isnt null, default_maxMemory, 2000))); \\
-    eval_set_remote_queue = ifThenElse(InputRSL.queue isnt null, InputRSL.queue, ifThenElse(batch_queue isnt null, batch_queue, ifThenElse(queue isnt null, queue, ifThenElse(default_queue isnt null, default_queue, "")))); \\
+    /* Note yet another nested condition allow pass attributes (maxMemory,xcount,jobtype,queue) via gWMS Factory described within ClassAd */ \\
+    eval_set_RequestMemory = ifThenElse(maxMemory isnt null, maxMemory, ifThenElse(default_maxMemory isnt null, default_maxMemory, 2000)); \\
+    eval_set_remote_queue = ifThenElse(batch_queue isnt null, batch_queue, ifThenElse(queue isnt null, queue, ifThenElse(default_queue isnt null, default_queue, ""))); \\
     /* HTCondor uses RequestCpus; blahp uses SMPGranularity and NodeNumber.  Default is 1 core. */ \\
-    eval_set_RequestCpus = ifThenElse(InputRSL.xcount isnt null, InputRSL.xcount, ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1))); \\
-    eval_set_remote_SMPGranularity = ifThenElse(InputRSL.xcount isnt null, InputRSL.xcount, ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1))); \\
-    eval_set_remote_NodeNumber = ifThenElse(InputRSL.xcount isnt null, InputRSL.xcount, ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1))); \\
+    eval_set_RequestCpus = ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1)); \\
+    eval_set_remote_SMPGranularity = ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1)); \\
+    eval_set_remote_NodeNumber = ifThenElse(xcount isnt null, xcount, ifThenElse(default_xcount isnt null, default_xcount, 1)); \\
     /* If remote_cerequirements is a string, BLAH will parse it as an expression before examining it */ \\
     eval_set_remote_cerequirements = strcat(ifThenElse(default_remote_cerequirements isnt null, strcat(string(default_remote_cerequirements), " && "), ""), \\
-      ifThenElse(InputRSL.maxWallTime isnt null, strcat("Walltime == ", string(60*InputRSL.maxWallTime), " && CondorCE == 1"), \\
-        ifThenElse(maxWallTime isnt null, strcat("Walltime == ", string(60*maxWallTime), " && CondorCE == 1"), \\
+      ifThenElse(maxWallTime isnt null, strcat("Walltime == ", string(60*maxWallTime), " && CondorCE == 1"), \\
           ifThenElse(default_maxWallTime isnt null, strcat("Walltime == ", string(60*default_maxWallTime), " && CondorCE == 1"), \\
-            "CondorCE == 1")))); \\
+            "CondorCE == 1"))); \\
     copy_OnExitHold = "orig_OnExitHold"; \\
     eval_set_OnExitHold = ifThenElse(orig_OnExitHold isnt null, orig_OnExitHold, false) || ifThenElse(minWalltime isnt null && RemoteWallClockTime isnt null, RemoteWallClockTime < 60*minWallTime, false); \\
     copy_OnExitHoldReason = "orig_OnExitHoldReason"; \\
@@ -75,24 +74,6 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
   ]
 """
 
-input_rsl = "\nset_InputRSL = ifThenElse(GlobusRSL is null, [], eval_rsl(GlobusRSL)); \\"
-
-# Long-winded hack to avoid using 'set_InputRSL' in the 8.0.x series due to
-# HTCondor bug #3772.
-version = '8.0.0'
-if classad:
-    version = classad.version()
-m = re.match(r"(\d+)\.(\d+)\.(\d+)", version)
-if m:
-    major, minor, bug = m.groups()
-    major = int(major)
-    minor = int(minor)
-    bug = int(bug)
-    if major < 8 or (major == 8 and minor < 1):
-        input_rsl = ''
-else:
-    input_rsl = ''
-
 # Allow admins to prevent pilots from advertising back to the CE.
 # https://ticket.grid.iu.edu/26666
 advertise_pilots =  '" CONDORCE_COLLECTOR_HOST=", CondorCECollectorHost, '
@@ -102,7 +83,7 @@ try:
 except KeyError:
     pass
 
-job_router_defaults = job_router_defaults % (advertise_pilots, input_rsl)
+job_router_defaults = job_router_defaults % advertise_pilots
 
 osg_environment_files = [ \
     "/var/lib/osg/osg-job-environment.conf",

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -8,7 +8,7 @@ ls -l /home
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm
 yum -y install yum-plugin-priorities
 rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el${OS_VERSION}-release-latest.rpm
-yum -y install rpm-build gcc gcc-c++ boost-devel globus-rsl-devel condor-classads-devel cmake git tar gzip make autotools
+yum -y install rpm-build gcc gcc-c++ boost-devel cmake git tar gzip make autotools
 
 # Prepare the RPM environment
 mkdir -p /tmp/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}


### PR DESCRIPTION
A few spots with references to the RSL/classad libraries were missed. Build passed here: https://travis-ci.org/brianhlin/htcondor-ce/builds/111019051

v2.0.1 should be ok though even if we leave the JOB_ROUTER_DEFAULTS RSL functions in there because of all the null value handling.