### PR TITLE
Make HTCondor-CE a noarch build

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -5,6 +5,7 @@ Name: htcondor-ce
 Version: 2.0.2
 Release: 1%{?gitrev:.%{gitrev}git}%{?dist}
 Summary: A framework to run HTCondor as a CE
+BuildArch: noarch
 
 Group: Applications/System
 License: Apache 2.0
@@ -145,13 +146,7 @@ Requires: /usr/bin/grid-proxy-init
 Requires: /usr/bin/voms-proxy-init
 Requires: grid-certificates >= 7
 
-# Require the appropriate version of the python library.  This
-# is rather awkward, but better syntax isn't available until RHEL6
-%ifarch x86_64
-Requires: htcondor.so()(64bit)
-%else
-Requires: htcondor.so()
-%endif
+Requires: condor-python
 
 Obsoletes: condor-ce-client < 0.5.4
 Provides:  condor-ce-client = %{version}

--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -2,7 +2,7 @@
 #define gitrev osg
 
 Name: htcondor-ce
-Version: 2.0.1
+Version: 2.0.2
 Release: 1%{?gitrev:.%{gitrev}git}%{?dist}
 Summary: A framework to run HTCondor as a CE
 
@@ -405,6 +405,9 @@ fi
 %attr(1777,root,root) %dir %{_localstatedir}/lib/gratia/condorce_data
 
 %changelog
+* Fri Feb 22 2016 Brian Lin <blin@cs.wisc.edu> - 2.0.2-1
+- Drop CE ClassAd functions from JOB_ROUTER_DEFAULTS
+
 * Wed Feb 07 2016 Brian Lin <blin@cs.wisc.edu> - 2.0.1-1
 - Fix htcondor-ce-view requirements to allow installation with an htcondor-ce-collector
 - Drop CE ClassAd functions

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -30,4 +30,4 @@ rpmbuild --define '_topdir /tmp/rpmbuild' -ba /tmp/rpmbuild/SPECS/htcondor-ce.sp
 # Fix the lock file error on EL7.  /var/lock is a symlink to /var/run/lock
 mkdir -p /var/run/lock
 
-yum localinstall -y /tmp/rpmbuild/RPMS/x86_64/htcondor-ce-client* /tmp/rpmbuild/RPMS/x86_64/htcondor-ce-${package_version}* /tmp/rpmbuild/RPMS/x86_64/htcondor-ce-view*
+yum localinstall -y /tmp/rpmbuild/RPMS/noarch/htcondor-ce-client* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-${package_version}* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-view*


### PR DESCRIPTION
Now that there's `condor-python` package available, we don't need to require the htcondor.so() directly and just let yum handle getting the proper architecture.