### PR TITLE
Accept subject DNs in extattr_table.txt (SOFTWARE-2243)

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -139,10 +139,15 @@ def set_accounting_group():
         return None
     accounting_group_str = ''
     for mapping in uid_mappings:
-        accounting_group_str += 'ifThenElse(Owner == %s, strcat(%s, ".", Owner), ' % (quote(mapping[0]), quote(mapping[1]))
+        accounting_group_str += 'ifThenElse(Owner == %s, strcat(%s, ".", Owner), ' % (quote(mapping[0]),
+                                                                                      quote(mapping[1]))
     for mapping in attr_mappings:
-        accounting_group_str += 'ifThenElse(regexp(%s, x509UserProxyFQAN), strcat(%s, ".", Owner), ' % (quote(mapping[0]), quote(mapping[1]))
-    accounting_group_str += "Owner " + ")"*(len(attr_mappings)+len(uid_mappings))
+        accounting_group_str += 'ifThenElse(regexp(%s, x509UserProxySubject), strcat(%s, ".", Owner), ' \
+                                % (quote(mapping[0]), quote(mapping[1]))
+        accounting_group_str += 'ifThenElse(x509UserProxyFirstFQAN isnt Undefined && ' + \
+                                'regexp(%s, x509UserProxyFirstFQAN), strcat(%s, ".", Owner), ' \
+                                % (quote(mapping[0]), quote(mapping[1]))
+    accounting_group_str += "Owner" + "))"*(len(attr_mappings)+len(uid_mappings))
     return accounting_group_str
 
 def condor_env_escape(val):

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -102,12 +102,12 @@ def parse_extattr():
         line = line.strip()
         if not line:
             continue
-        info = line.split(" ", 1)
+        info = line.rsplit(" ", 1)
         if len(info) != 2:
             continue
-        results.append( (info[0], str(info[1]).strip()) )
+        results.append((str(info[0].strip()), str(info[1]).strip()))
     return results
-        
+
 
 def parse_uids():
     if not os.path.exists("/etc/osg/uid_table.txt"):
@@ -141,7 +141,7 @@ def set_accounting_group():
     for mapping in uid_mappings:
         accounting_group_str += 'ifThenElse(Owner == %s, strcat(%s, ".", Owner), ' % (quote(mapping[0]), quote(mapping[1]))
     for mapping in attr_mappings:
-        accounting_group_str += 'ifThenElse(regexp(%s, x509UserProxyFirstFQAN), strcat(%s, ".", Owner), ' % (quote(mapping[0]), quote(mapping[1]))
+        accounting_group_str += 'ifThenElse(regexp(%s, x509UserProxyFQAN), strcat(%s, ".", Owner), ' % (quote(mapping[0]), quote(mapping[1]))
     accounting_group_str += "Owner " + ")"*(len(attr_mappings)+len(uid_mappings))
     return accounting_group_str
 

--- a/src/condor_ce_trace
+++ b/src/condor_ce_trace
@@ -176,32 +176,30 @@ def generate_run_script(job_info):
 
 def add_job_proxy_info(job_ad):
 
-    fd = os.popen("voms-proxy-info -file %s -subject" % job_ad['x509userproxy'])
-    output = fd.read().strip()
-    if fd.close():
+    subj_rc, subj_stdout, _ = ce.run_command(["voms-proxy-info", "-file", job_ad['x509userproxy'], "-subject"])
+    if subj_rc != 0:
         raise ce.CondorUserException("Cannot parse proxy at %s." % job_ad['x509userproxy'])
-    job_ad['x509userproxysubject'] = output
+    subj_stdout = subj_stdout.strip()
+    job_ad['x509userproxysubject'] = subj_stdout
+    job_ad['x509UserProxyFQAN'] = subj_stdout
 
-    fd = os.popen("voms-proxy-info -file %s -timeleft" % job_ad['x509userproxy'])
-    output = fd.read().strip()
-    if fd.close():
+    time_rc, time_stdout, _ = ce.run_command(["voms-proxy-info", "-file", job_ad['x509userproxy'], "-timeleft"])
+    if time_rc != 0:
         raise ce.CondorUserException("Cannot parse proxy at %s." % job_ad['x509userproxy'])
-    output = int(output)
-    if output <= 0:
+    time_stdout = int(time_stdout)
+    if time_stdout <= 0:
         print "WARNING: available proxy appears to be expired"
-    job_ad['x509UserProxyExpiration'] = int(time.time()) + int(output)
+    job_ad['x509UserProxyExpiration'] = int(time.time()) + int(time_stdout)
 
-    fd = os.popen("voms-proxy-info -file %s -vo" % job_ad['x509userproxy'])
-    output = fd.read().strip()
-    if not fd.close():
-        job_ad['x509UserProxyVOName'] = output
+    vo_rc, vo_stdout, _ = ce.run_command(["voms-proxy-info", "-file", job_ad['x509userproxy'], "-vo"])
+    if vo_rc == 0:
+        job_ad['x509UserProxyVOName'] = vo_stdout.strip()
 
-    fd = os.popen("voms-proxy-info -file %s -fqan" % job_ad['x509userproxy'])
-    output_lines = fd.readlines()
-    if not fd.close():
-        output_lines = [i.strip() for i in output_lines]
-        job_ad['x509UserProxyFirstFQAN'] = output_lines[0]
-        job_ad['x509UserProxyFQAN'] = ",".join(output_lines)
+    fqan_rc, fqan_stdout, _ = ce.run_command(["voms-proxy-info", "-file", job_ad['x509userproxy'], "-fqan"])
+    if fqan_rc == 0:
+        fqan_lines = [i.strip() for i in fqan_stdout.strip().split('\n')]
+        job_ad['x509UserProxyFirstFQAN'] = fqan_lines[0]
+        job_ad['x509UserProxyFQAN'] += "," + ",".join(fqan_lines)
 
     if G_DEBUG:
         print "Job ad, pre-submit:", job_ad

--- a/src/htcondorce/tools.py
+++ b/src/htcondorce/tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+"""Utility library for HTCondor-CE tools"""
 
 import errno
 import os
@@ -12,12 +12,15 @@ from subprocess import Popen, PIPE
 JOB_FILES = ['stdout', 'stderr', 'log']
 
 class CondorRunException(Exception):
+    """Exception for handling errors from HTCondor"""
     pass
 
 class CondorUserException(Exception):
+    """Exception for handling user errors"""
     pass
 
 def print_formatted_msg(msg):
+    """Limit output messages to 80 characters in width"""
     print "*"*80
     wrapper = textwrap.TextWrapper(width=80, replace_whitespace=False)
     for line in wrapper.wrap(msg):
@@ -25,14 +28,17 @@ def print_formatted_msg(msg):
     print "*"*80
 
 def print_timestamped_msg(msg):
+    """Prepend the current date and time to a message"""
     print_formatted_msg("%s %s" % (time.strftime('%F %T'), msg))
 
 def run_command(command):
+    """Run a command and return its return code, stdout, and stderr"""
     p = Popen(command, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     return p.returncode, stdout, stderr
 
 def generate_job_files():
+    """Create temporary job log, stdout, and stderr files"""
     pid = os.getpid()
     job_info = {}
     for filetype in JOB_FILES:
@@ -41,6 +47,7 @@ def generate_job_files():
     return job_info
 
 def cleanup_job_files(job_info):
+    """Remove temporary job log, stdout, and stderr files  """
     for filetype in JOB_FILES + ['submit']:
         try:
             os.unlink(job_info[filetype + '_file'])


### PR DESCRIPTION
This patch allows HTCondor-CE to use lines out of `/etc/osg/extattr_table.txt` to be matched against the user's subject DN in addition to their VOMS attributes. Instead of [x509UserProxyFirstFQAN](http://research.cs.wisc.edu/htcondor/manual/v8.4/12_Appendix_A.html#100112), we use [x509UserProxyFQAN](http://research.cs.wisc.edu/htcondor/manual/v8.4/12_Appendix_A.html#100116), which includes the subject DN as well as the VOMS FQAN in a single attribute.

`condor_ce_trace` was also fixed to generate an `x509UserProxyFQAN` that mimics the format of the attribute created via `condor_submit`.

