### PR TITLE
Fix bug for incorrect number of parens (SOFTWARE-2243)

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -147,7 +147,7 @@ def set_accounting_group():
         accounting_group_str += 'ifThenElse(x509UserProxyFirstFQAN isnt Undefined && ' + \
                                 'regexp(%s, x509UserProxyFirstFQAN), strcat(%s, ".", Owner), ' \
                                 % (quote(mapping[0]), quote(mapping[1]))
-    accounting_group_str += "Owner" + "))"*(len(attr_mappings)+len(uid_mappings))
+    accounting_group_str += "Owner" + ")"*(len(attr_mappings)*2+len(uid_mappings))
     return accounting_group_str
 
 def condor_env_escape(val):


### PR DESCRIPTION
Tested this against:

- Empty `uid_table.txt`, contents in `extattr_table.txt`
- Contents in `uid_table.txt`, empty `extattr_table.txt`
- Contents in both `uid_table.txt` and `extattr_table.txt`

Time to start working on those unit tests...