### PR TITLE
Adding Schedd to the CEView for the Schedd Cron

### DIFF
--- a/config/05-ce-view.conf
+++ b/config/05-ce-view.conf
@@ -11,8 +11,8 @@
 # To enable the webapp, uncomment the line below:
 # DAEMON_LIST = $(DAEMON_LIST), CEVIEW, GANGLIAD, SCHEDD
 
-# If this is only a CE View, or a ce-collector, then uncomment below to
-# not allow any job submissions to the schedd.
+# If this node is a dedicated CE View, or a htcondor-ce-collector, then uncomment 
+# below to not allow any job submissions to the schedd.
 # SCHEDD.ALLOW_WRITE = FALSE
 
 # By default, CEView will listen on port 80; this can be changed below.
@@ -30,4 +30,3 @@ HTCONDORCE_VIEW_PORT = 80
 # CEVIEW.SEC_CLIENT_NEGOTIATION = OPTIONAL
 # NOTE: Unless you significantly changed the security configuration of your CE,
 # you don't need this.
-

--- a/config/05-ce-view.conf
+++ b/config/05-ce-view.conf
@@ -9,7 +9,11 @@
 # This provides a simple interface for monitoring the activity on your CE.
 
 # To enable the webapp, uncomment the line below:
-# DAEMON_LIST = $(DAEMON_LIST), CEVIEW, GANGLIAD
+# DAEMON_LIST = $(DAEMON_LIST), CEVIEW, GANGLIAD, SCHEDD
+
+# If this is only a CE View, or a ce-collector, then uncomment below to
+# not allow any job submissions to the schedd.
+# SCHEDD.ALLOW_WRITE = FALSE
 
 # By default, CEView will listen on port 80; this can be changed below.
 


### PR DESCRIPTION
Adding the Schedd for dedicated ce-collectors and ce-view machines.
The Schedd is necessary for the Schedd cron which runs the metrics
updates.  Additionally, add example configuration which will turn
off all job submission abilities to this schedd.

SOFTWARE-2268