### PR TITLE
Accounting Group unit tests

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -91,10 +91,10 @@ osg_environment_files = [ \
 ]
 
 
-def parse_extattr():
-    if not os.path.exists("/etc/osg/extattr_table.txt"):
+def parse_extattr(extattr_file):
+    if not os.path.exists(extattr_file):
         return []
-    fd = open("/etc/osg/extattr_table.txt")
+    fd = open(extattr_file)
     results = []
     for line in fd:
         if line.startswith("#"):
@@ -109,10 +109,10 @@ def parse_extattr():
     return results
 
 
-def parse_uids():
-    if not os.path.exists("/etc/osg/uid_table.txt"):
+def parse_uids(uid_file):
+    if not os.path.exists(uid_file):
         return []
-    fd = open("/etc/osg/uid_table.txt")
+    fd = open(uid_file)
     results = []
     for line in fd:
         if line.startswith("#"):
@@ -130,9 +130,9 @@ def parse_uids():
             results.append( (info[0], str(info[1]).strip()) )
     return results
 
-def set_accounting_group():
-    attr_mappings = parse_extattr()
-    uid_mappings = parse_uids()
+def set_accounting_group(uid_file="/etc/osg/uid_table.txt", extattr_file="/etc/osg/extattr_table.txt"):
+    attr_mappings = parse_extattr(extattr_file)
+    uid_mappings = parse_uids(uid_file)
     if not classad: 
         return "Owner"
     elif not attr_mappings and not uid_mappings:

--- a/tests/extattr_table.txt
+++ b/tests/extattr_table.txt
@@ -1,0 +1,23 @@
+# extended-attribute matching table
+# format: [perl regular expression] [group]
+# examples:
+
+# FIFE preprod testing
+#/DC=org/DC=opensciencegrid/O=Open\ Science\ Grid/OU=Services/CN=frontend_pp/fifebatch\.fnal\.gov  group_preprod
+
+# Fermilab VO
+\/fermilab\/Role=pilot                                                                             group_fermilab
+
+# DES pilots
+#/DC=com/DC=DigiCert-Grid/O=Open\ Science\ Grid/OU=People/CN=Greg\ Daues\ 1912                     group_des
+#/DC=com/DC=DigiCert-Grid/O=Open\ Science\ Grid/OU=People/CN=Michelle\ Gower\ 1913                 group_des
+#/DC=com/DC=DigiCert-Grid/O=Open\ Science\ Grid/OU=People/CN=Felipe\ Menanteau\ 3137               group_des
+#/DC=com/DC=DigiCert-Grid/O=Open\ Science\ Grid/OU=People/CN=Douglas Nathaniel\ Friedel\ 3371      group_des
+\/DC=com\/DC=DigiCert-Grid\/O=Open\ Science\ Grid\/OU=People\/CN=Michael\ Johnson\ 2274            group_des
+#/DC=com/DC=DigiCert-Grid/O=Open\ Science\ Grid/OU=People/CN=Eric\ Morganson\ 3317                 group_des
+#/DC=com/DC=DigiCert-Grid/O=Open\ Science\ Grid/OU=People/CN=Xinyang\ Lu\ 3630                     group_des
+#/DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Brian\ P\.\ Yanny/CN=UID\:yanny                           group_des
+
+# CMS opportunistic testing
+#/DC=ch/DC=cern/OU=Organic\ Units/OU=Users/CN=mohapatr/CN=659205/CN=Ajit\ Kumar\ Mohapatra         group_cms
+\/DC=com\/DC=DigiCert-Grid\/O=Open\ Science\ Grid\/OU=People\/CN=Brian\ Lin\ 1047                  group_test

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,12 @@
+#!/bin/env python
+"""Run HTCondor-CE unit tests"""
+
+import glob
+import unittest
+
+TESTS = [test.strip('.py') for test in glob.glob('test*.py')]
+SUITE = unittest.TestLoader().loadTestsFromNames(TESTS)
+unittest.TextTestRunner(verbosity=2).run(SUITE)
+
+
+

--- a/tests/test_condor_ce_router_defaults.py
+++ b/tests/test_condor_ce_router_defaults.py
@@ -1,0 +1,40 @@
+#/usr/bin/env python
+"""Unit tests for condor_ce_router_defaults"""
+
+import imp
+import os
+import re
+import unittest
+
+EXTATTR_FILE_PATH = 'extattr_table.txt'
+UID_FILE_PATH = 'uid_table.txt'
+DEFAULTS_PATH = os.path.join('..', 'src', 'condor_ce_router_defaults')
+
+defaults = imp.load_source('condor_ce_router_defaults', DEFAULTS_PATH)
+
+class TestDefaults(unittest.TestCase):
+    """Unit tests for condor_ce_router_defaults"""
+
+    def test_parse_extattr(self):
+        """Verify extattr_table.txt returns expected list of tuples"""
+        dn_prefix = "\\/DC=com\\/DC=DigiCert-Grid\\/O=Open\\ Science\\ Grid\\/OU=People\\/CN="
+        extattr = defaults.parse_extattr(EXTATTR_FILE_PATH)
+        expected_extattr = [('\\/fermilab\\/Role=pilot', 'group_fermilab'),
+                            ('%sMichael\\ Johnson\\ 2274' % dn_prefix, 'group_des'),
+                            ('%sBrian\\ Lin\\ 1047' % dn_prefix, 'group_test')]
+        self.assertEqual(extattr, expected_extattr, '\nExpected: %s\n\nGot: %s\n' % (expected_extattr, extattr))
+
+    def test_parse_uids(self):
+        """Verify uid_table.txt returns expected list of tuples"""
+        uids = defaults.parse_uids(UID_FILE_PATH)
+        expected_uids = [('uscms02', 'TestGroup'), ('osg', 'other.osgedu')]
+        self.assertEqual(uids, expected_uids, '\nExpected: %s\n\nGot: %s\n' % (expected_uids, uids))
+
+    def test_set_accounting_group(self):
+        """Verify classad functions have matching closing parentheses"""
+        acct_grp_expr = defaults.set_accounting_group(UID_FILE_PATH, EXTATTR_FILE_PATH)
+        num_classad_fn = len(re.findall(r'[(?:ifThenElse)(?:regexp)(?:strcat)]\(', acct_grp_expr))
+        num_closing_parens = len(re.findall(r'\)', acct_grp_expr))
+        self.assertEqual(num_classad_fn, num_closing_parens,
+                         'Mismatched "ifThenElse_fn(" + "regexp(" + "strcat(" statements (%s) and closing parentheses (%s)'
+                         % (num_classad_fn, num_closing_parens))

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -31,3 +31,8 @@ rpmbuild --define '_topdir /tmp/rpmbuild' -ba /tmp/rpmbuild/SPECS/htcondor-ce.sp
 mkdir -p /var/run/lock
 
 yum localinstall -y /tmp/rpmbuild/RPMS/noarch/htcondor-ce-client* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-${package_version}* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-view*
+
+# Run unit tests
+pushd htcondor-ce/tests
+python -m unittest -v test_condor_ce_router_defaults
+popd

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -33,6 +33,6 @@ mkdir -p /var/run/lock
 yum localinstall -y /tmp/rpmbuild/RPMS/noarch/htcondor-ce-client* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-${package_version}* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-view*
 
 # Run unit tests
-pushd htcondor-ce/tests
-python -m unittest -v test_condor_ce_router_defaults
+pushd htcondor-ce/tests/
+python run_tests.py
 popd

--- a/tests/uid_table.txt
+++ b/tests/uid_table.txt
@@ -1,0 +1,6 @@
+# This is a comment
+uscms02 TestGroup
+
+# This is another comment
+osg     other.osgedu
+


### PR DESCRIPTION
I wrote some unit tests for `condor_ce_router_defaults` that test the `AccountingGroupOSG` generator functions. They've also been added to the Travis-CI tests.