### PR TITLE
Adjust hold message for reaching MaxJobs or MaxIdleJobs

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -49,7 +49,7 @@ SYSTEM_PERIODIC_HOLD_REASON = \
        ifThenElse(time() > x509UserProxyExpiration, "expired user proxy.", \
          ifThenElse(RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12, \
            "invalid job universe.", \
-           "non-existent route or entry in JOB_ROUTER_ENTRIES." \
+           "non-existent route in JOB_ROUTER_ENTRIES or route job limit." \
          ) \
        ) \
      ) \

--- a/config/01-ce-router.conf.in
+++ b/config/01-ce-router.conf.in
@@ -45,7 +45,7 @@ SYSTEM_PERIODIC_HOLD_REASON = \
        ifThenElse(time() > x509UserProxyExpiration, "expired user proxy.", \
          ifThenElse(RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12, \
            "invalid job universe.", \
-           "non-existent route or entry in JOB_ROUTER_ENTRIES." \
+           "non-existent route in JOB_ROUTER_ENTRIES or route job limit." \
          ) \
        ) \
      ) \


### PR DESCRIPTION
We've been seeing this more among sites. I don't think there's a way to differentiate between the job not matching any routes or the routes being full from the JobAd so this is better than nothing.