### PR TITLE
Add child as authorized daemon.

### DIFF
--- a/config/01-ce-auth-defaults.conf
+++ b/config/01-ce-auth-defaults.conf
@@ -15,7 +15,7 @@ DENY_ADMINISTRATOR = anonymous@*, unmapped@*
 DENY_DAEMON = anonymous@*, unmapped@*
 
 # Defaults authorizations
-FRIENDLY_DAEMONS = $(FULL_HOSTNAME)@daemon.opensciencegrid.org/$(FULL_HOSTNAME) condor@users.opensciencegrid.org/$(FULL_HOSTNAME)
+FRIENDLY_DAEMONS = $(FULL_HOSTNAME)@daemon.opensciencegrid.org/$(FULL_HOSTNAME) condor@users.opensciencegrid.org/$(FULL_HOSTNAME) condor@child/$(FULL_HOSTNAME)
 # Setting the UID_DOMAIN appends @users.opensciencegrid.org to GUMS mappings.
 UID_DOMAIN = users.opensciencegrid.org
 USERS = *@users.opensciencegrid.org

--- a/config/01-ce-auth.conf
+++ b/config/01-ce-auth.conf
@@ -13,7 +13,7 @@ DENY_DAEMON = anonymous@*, unmapped@*
 DENY_OWNER = anonymous@*, unmapped@*
 
 # Defaults authorizations
-FRIENDLY_DAEMONS = $(FULL_HOSTNAME)@daemon.opensciencegrid.org/$(FULL_HOSTNAME) condor@users.opensciencegrid.org/$(FULL_HOSTNAME)
+FRIENDLY_DAEMONS = $(FULL_HOSTNAME)@daemon.opensciencegrid.org/$(FULL_HOSTNAME) condor@users.opensciencegrid.org/$(FULL_HOSTNAME) condor@child/$(FULL_HOSTNAME)
 # Setting the UID_DOMAIN appends @users.opensciencegrid.org to GUMS mappings.
 UID_DOMAIN = users.opensciencegrid.org
 USERS = *@users.opensciencegrid.org


### PR DESCRIPTION
Fixes [SOFTWARE-2280](https://jira.opensciencegrid.org/browse/SOFTWARE-2280):

> The GridManager needs permissions to file transfers. Current fix is to add condor@child/$(FULL_HOSTNAME) to FRIENDLY_DAEMONS from 01-ce-auth.conf.