### PR TITLE
Add expire-cache cleaning since it's skipped with 'yum clean all'

### DIFF
--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -6,6 +6,7 @@ ls -l /home
 
 # Clean the yum cache
 yum -y clean all
+yum -y clean expire-cache
 
 # First, install all the needed packages.
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm


### PR DESCRIPTION
Even though the 3.2.29 yum man page says `yum clean all` performs all of the clean options, closer inspection of the client shows that it skips the `expire-cache` option. We perform the same two  commands in [osg-test](https://github.com/brianhlin/osg-test/blob/master/osgtest/library/yum.py#L16).