### PR TITLE
Enable osg-test run for travis-ci PRs.

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -28,6 +28,9 @@ Requires:  condor >= 8.3.7
 # This ought to pull in the HTCondor-CE specific version of the blahp
 Requires: blahp
 
+# Init script doesn't function without `which` (which is no longer part of RHEL7 base).
+Requires: which
+
 # Require the htcondor-ce-client subpackage.  The client provides necessary
 # configuration defaults and scripts for the CE itself.
 Requires: %{name}-client = %{version}-%{release}

--- a/src/condor_ce_trace
+++ b/src/condor_ce_trace
@@ -260,7 +260,7 @@ def check_job_submit(job_info):
 
     print "- Successful spooling"
 
-    attempts = htcondor.param.get("CONDOR_CE_TRACE_ATTEMPTS", 600)
+    attempts = int(htcondor.param.get("CONDOR_CE_TRACE_ATTEMPTS", 600))
     last_status = -1
     for attempt in range(attempts):
         if G_DEBUG:

--- a/src/condor_ce_trace
+++ b/src/condor_ce_trace
@@ -260,7 +260,7 @@ def check_job_submit(job_info):
 
     print "- Successful spooling"
 
-    attempts = 600
+    attempts = htcondor.param.get("CONDOR_CE_TRACE_ATTEMPTS", 600)
     last_status = -1
     for attempt in range(attempts):
         if G_DEBUG:

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -54,6 +54,7 @@ popd
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 # Don't cleanup so we can do reasonable debug printouts later.
+echo "127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4 `hostname`" > /etc/hosts
 osg-test -vad --hostcert --no-cleanup
 openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
 cat /var/log/condor-ce/MasterLog

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -59,6 +59,6 @@ osg-test -vad --hostcert --no-cleanup
 openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
 cat /var/log/condor-ce/MasterLog
 cat /var/log/condor-ce/CollectorLog
-cat /var/log/condor-ce/ScheddLog
+cat /var/log/condor-ce/SchedLog
 _condor_COLLECTOR_PORT=9619 condor_status -schedd -l | sort
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -53,7 +53,7 @@ popd
 # RPM version of osg-test
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
-osg-test -vad
+osg-test -vad --hostcert
 cat /var/log/condor-ce/CollectorLog
 cat /var/log/condor-ce/ScheddLog
 _condor_COLLECTOR_PORT=9619 condor_status -schedd -l | sort

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -41,10 +41,13 @@ pushd htcondor-ce/tests/
 python run_tests.py
 popd
 
-git clone https://github.com/opensciencegrid/osg-test.git
-pushd osg-test
-make install
-popd
+# Source repo version
+#git clone https://github.com/opensciencegrid/osg-test.git
+#pushd osg-test
+#make install
+#popd
+# RPM version of osg-test
+yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 osg-test -vad
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -61,7 +61,7 @@ yum -y install --enablerepo=osg-testing osg-test
 
 # HTCondor really, really wants a domain name.  Fake one.
 sed /etc/hosts -e "s/`hostname`/`hostname`.unl.edu `hostname`/" > /etc/hosts.new
-mv /etc/hosts.new /etc/hosts
+/bin/cp -f /etc/hosts.new /etc/hosts
 echo "127.0.0.1 localhost.localdomain localhost localhost4 localhost4.localdomain4 `hostname`" > /etc/hosts
 
 # Bind on the right interface and skip hostname checks.

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -55,7 +55,7 @@ popd
 #make install
 #popd
 # RPM version of osg-test
-yum -y install --enablerepo=osg-testing osg-test
+yum -y install --enablerepo=osg-testing osg-test osg-configure
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 # Don't cleanup so we can do reasonable debug printouts later.
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -53,7 +53,8 @@ popd
 # RPM version of osg-test
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
-osg-test -vad --hostcert
+# Don't cleanup so we can do reasonable debug printouts later.
+osg-test -vad --hostcert --no-cleanup
 openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
 cat /var/log/condor-ce/MasterLog
 cat /var/log/condor-ce/CollectorLog

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -62,7 +62,6 @@ yum -y install --enablerepo=osg-testing osg-test
 # HTCondor really, really wants a domain name.  Fake one.
 sed /etc/hosts -e "s/`hostname`/`hostname`.unl.edu `hostname`/" > /etc/hosts.new
 /bin/cp -f /etc/hosts.new /etc/hosts
-echo "127.0.0.1 localhost.localdomain localhost localhost4 localhost4.localdomain4 `hostname`" > /etc/hosts
 
 # Bind on the right interface and skip hostname checks.
 cat << EOF > /etc/condor/config.d/99-local.conf

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -10,6 +10,10 @@ yum -y clean expire-cache
 
 # First, install all the needed packages.
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm
+
+# Broken mirror?
+echo "exclude=mirror.beyondhosting.net" >> /etc/yum/pluginconf.d/fastestmirror.conf
+
 yum -y install yum-plugin-priorities
 rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el${OS_VERSION}-release-latest.rpm
 yum -y install rpm-build gcc gcc-c++ boost-devel cmake git tar gzip make autotools

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -38,7 +38,7 @@ rpmbuild --define '_topdir /tmp/rpmbuild' -ba /tmp/rpmbuild/SPECS/htcondor-ce.sp
 # Fix the lock file error on EL7.  /var/lock is a symlink to /var/run/lock
 mkdir -p /var/run/lock
 
-yum localinstall -y /tmp/rpmbuild/RPMS/noarch/htcondor-ce-client* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-${package_version}* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-view*
+yum localinstall -y /tmp/rpmbuild/RPMS/noarch/htcondor-ce-client* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-${package_version}* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-condor-${package_version}* /tmp/rpmbuild/RPMS/noarch/htcondor-ce-view*
 
 # Run unit tests
 pushd htcondor-ce/tests/

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -54,6 +54,8 @@ popd
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 osg-test -vad --hostcert
+openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
+cat /var/log/condor-ce/MasterLog
 cat /var/log/condor-ce/CollectorLog
 cat /var/log/condor-ce/ScheddLog
 _condor_COLLECTOR_PORT=9619 condor_status -schedd -l | sort

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -78,9 +78,14 @@ osg-test -vad --hostcert --no-cleanup
 
 # Some simple debug files for failures.
 openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
+echo "------------ CE Logs --------------"
 cat /var/log/condor-ce/MasterLog
 cat /var/log/condor-ce/CollectorLog
 cat /var/log/condor-ce/SchedLog
 cat /var/log/condor-ce/JobRouterLog
 _condor_COLLECTOR_PORT=9619 condor_status -schedd -l | sort
-
+echo "------------ HTCondor Logs --------------"
+cat /var/log/condor/MasterLog
+cat /var/log/condor/CollectorLog
+cat /var/log/condor/SchedLog
+condor_status -schedd -l | sort

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -70,6 +70,9 @@ GSI_SKIP_HOST_CHECK=true
 EOF
 cp /etc/condor/config.d/99-local.conf /etc/condor-ce/config.d/99-local.conf
 
+# Reduce the trace timeouts
+export _condor_CONDOR_CE_TRACE_ATTEMPTS=60
+
 # Ok, do actual testing
 osg-test -vad --hostcert --no-cleanup
 
@@ -78,5 +81,6 @@ openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
 cat /var/log/condor-ce/MasterLog
 cat /var/log/condor-ce/CollectorLog
 cat /var/log/condor-ce/SchedLog
+cat /var/log/condor-ce/JobRouterLog
 _condor_COLLECTOR_PORT=9619 condor_status -schedd -l | sort
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -45,5 +45,6 @@ git clone https://github.com/opensciencegrid/osg-test.git
 pushd osg-test
 make install
 popd
-osg-test htcondor-ce -vad
+# osg-test will automatically determine the correct tests to run based on the RPMs installed.
+osg-test -vad
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -54,6 +54,7 @@ popd
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 # Don't cleanup so we can do reasonable debug printouts later.
+hostname localhost.localdomain
 echo "127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4 `hostname`" > /etc/hosts
 osg-test -vad --hostcert --no-cleanup
 openssl x509 -in /etc/grid-security/hostcert.pem -noout -text

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -68,6 +68,8 @@ cat << EOF > /etc/condor/config.d/99-local.conf
 NETWORK_INTERFACE=eth0
 GSI_SKIP_HOST_CHECK=true
 SCHEDD_DEBUG=\$(SCHEDD_DEBUG) D_FULLDEBUG
+SCHEDD_INTERVAL=1
+SCHEDD_MIN_INTERVAL=1
 EOF
 cp /etc/condor/config.d/99-local.conf /etc/condor-ce/config.d/99-local.conf
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -40,3 +40,10 @@ yum localinstall -y /tmp/rpmbuild/RPMS/noarch/htcondor-ce-client* /tmp/rpmbuild/
 pushd htcondor-ce/tests/
 python run_tests.py
 popd
+
+git clone https://github.com/opensciencegrid/osg-test.git
+pushd osg-test
+make install
+popd
+osg-test htcondor-ce -vad
+

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -46,8 +46,15 @@ popd
 #pushd osg-test
 #make install
 #popd
+#git clone https://github.com/opensciencegrid/osg-ca-generator.git
+#pushd osg-ca-generator
+#make install
+#popd
 # RPM version of osg-test
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 osg-test -vad
+cat /var/log/condor-ce/CollectorLog
+cat /var/log/condor-ce/ScheddLog
+_condor_COLLECTOR_PORT=9619 condor_status -schedd -l | sort
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -67,7 +67,7 @@ sed /etc/hosts -e "s/`hostname`/`hostname`.unl.edu `hostname`/" > /etc/hosts.new
 cat << EOF > /etc/condor/config.d/99-local.conf
 NETWORK_INTERFACE=eth0
 GSI_SKIP_HOST_CHECK=true
-SCHEDD_DEBUG=$(SCHEDD_DEBUG) D_FULLDEBUG
+SCHEDD_DEBUG=\$(SCHEDD_DEBUG) D_FULLDEBUG
 EOF
 cp /etc/condor/config.d/99-local.conf /etc/condor-ce/config.d/99-local.conf
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -67,6 +67,7 @@ sed /etc/hosts -e "s/`hostname`/`hostname`.unl.edu `hostname`/" > /etc/hosts.new
 cat << EOF > /etc/condor/config.d/99-local.conf
 NETWORK_INTERFACE=eth0
 GSI_SKIP_HOST_CHECK=true
+SCHEDD_DEBUG=$(SCHEDD_DEBUG) D_FULLDEBUG
 EOF
 cp /etc/condor/config.d/99-local.conf /etc/condor-ce/config.d/99-local.conf
 
@@ -88,4 +89,5 @@ echo "------------ HTCondor Logs --------------"
 cat /var/log/condor/MasterLog
 cat /var/log/condor/CollectorLog
 cat /var/log/condor/SchedLog
+condor_config_val -dump
 condor_status -schedd -l | sort

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -54,8 +54,7 @@ popd
 yum -y install --enablerepo=osg-testing osg-test
 # osg-test will automatically determine the correct tests to run based on the RPMs installed.
 # Don't cleanup so we can do reasonable debug printouts later.
-hostname localhost.localdomain
-echo "127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4 `hostname`" > /etc/hosts
+echo "127.0.0.1 localhost.localdomain localhost localhost4 localhost4.localdomain4 `hostname`" > /etc/hosts
 osg-test -vad --hostcert --no-cleanup
 openssl x509 -in /etc/grid-security/hostcert.pem -noout -text
 cat /var/log/condor-ce/MasterLog


### PR DESCRIPTION
Let's see if osg-test can run quickly enough to make sense for the CI build.