### PR TITLE
Adding -xe to bash command for testing

### DIFF
--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -16,10 +16,7 @@ docker run --privileged -d -ti -e "container=docker"  -v /sys/fs/cgroup:/sys/fs/
 DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
 docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec "bash -xe /htcondor-ce/tests/test_inside_docker.sh ${OS_VERSION};
-  echo -ne \"------\nEND HTCONDOR-CE TESTS\n------\nSystemD Units:\n------\n\"; 
-  systemctl --no-pager --all --full status;
-  echo -ne \"------\nJournalD Logs:\n------\n\" ;
-  journalctl --catalog --all --full --no-pager;"
+  echo -ne \"------\nEND HTCONDOR-CE TESTS\n\";"
 docker ps -a
 docker stop $DOCKER_CONTAINER_ID
 docker rm -v $DOCKER_CONTAINER_ID

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -15,7 +15,7 @@ elif [ "$el_version" = "7" ]; then
 docker run --privileged -d -ti -e "container=docker"  -v /sys/fs/cgroup:/sys/fs/cgroup -v `pwd`:/htcondor-ce:rw  centos:centos${OS_VERSION}   /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
-docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -c "bash -xe /htcondor-ce/tests/test_inside_docker.sh ${OS_VERSION};
+docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec "bash -xe /htcondor-ce/tests/test_inside_docker.sh ${OS_VERSION};
   echo -ne \"------\nEND HTCONDOR-CE TESTS\n------\nSystemD Units:\n------\n\"; 
   systemctl --no-pager --all --full status;
   echo -ne \"------\nJournalD Logs:\n------\n\" ;


### PR DESCRIPTION
Adding the `-xe` command for testing so that if any of the command exits with non-zero status, all of it will exit.