### PR TITLE
condor_ce tools should print exception to stdout when using -verbose …

### DIFF
--- a/src/condor_ce_trace
+++ b/src/condor_ce_trace
@@ -348,19 +348,24 @@ def main():
 if __name__ == '__main__':
     try:
         main()
-    except (ce.CondorRunException, ce.CondorUserException, RuntimeError), e:
-        ce.print_timestamped_msg(e)
+    except (ce.CondorRunException, ce.CondorUserException, RuntimeError), tool_exc:
+        ce.print_timestamped_msg(tool_exc)
         sys.exit(1)
-    except Exception, e:
-        pid = os.getpid()
-        try:
-            fd, stack_file = tempfile.mkstemp(dir=".", prefix=".stack_%d_" % pid)
-            f = os.fdopen(fd, 'w')
-            f.write('%s\n' % time.strftime('%Y-%m-%d %H:%M:%S'))
-            traceback.print_exc(file=f)
-            f.close()
-            ce.print_formatted_msg('Uncaught exception, please send %s to goc@opensciencegrid.org with a description ' \
-                                   'of the issue.' % stack_file)
-        except OSError, e:
-            ce.print_formatted_msg("Unable to write stackfile due to the following error:\n%s" % e)
+    except Exception:
+        PID = os.getpid()
+        if G_DEBUG:
+            ce.print_formatted_msg('Uncaught exception, please send the following error to goc@opensciencegrid.org ' \
+                                   'with a description of the issue:\n%s' % traceback.format_exc())
+        else:
+            try:
+                FD, STACK_FILE = tempfile.mkstemp(dir=".", prefix=".stack_%d_" % PID)
+                F = os.fdopen(FD, 'w')
+                F.write('%s\n' % time.strftime('%Y-%m-%d %H:%M:%S'))
+                traceback.print_exc(file=F)
+                F.close()
+                ce.print_formatted_msg('Uncaught exception, please send %s to goc@opensciencegrid.org with a ' \
+                                       'description of the issue.' % STACK_FILE)
+            except OSError, write_exc:
+                ce.print_formatted_msg("Unable to write stackfile due to the following error:\n%s"
+                                       % traceback.format_exc())
         sys.exit(1)

--- a/src/htcondorce/tools.py
+++ b/src/htcondorce/tools.py
@@ -22,9 +22,9 @@ class CondorUserException(Exception):
 def print_formatted_msg(msg):
     """Limit output messages to 80 characters in width"""
     print "*"*80
-    wrapper = textwrap.TextWrapper(width=80, replace_whitespace=False)
-    for line in wrapper.wrap(msg):
-        print line
+    wrapper = textwrap.TextWrapper(width=80)
+    for line in msg.split('\n'):
+        print wrapper.fill(line)
     print "*"*80
 
 def print_timestamped_msg(msg):


### PR DESCRIPTION
…(SOFTWARE-2211)

- I had to adjust the printing slightly so that the traceback formatting doesn't break.
- Some variable renames to appease pylint