### PR TITLE
Ensure lockdir and rundir exist with correct permissions on startup

### DIFF
--- a/src/condor-ce
+++ b/src/condor-ce
@@ -59,6 +59,12 @@ fail() {
 start() {
     echo -n $"Starting Condor-CE daemons: "
 
+    # Ensure the condor-ce rundir and lockdir exist
+    local rundir=$(condor_ce_config_val RUN)
+    local lockdir=$(condor_ce_config_val LOCK)
+    mkdir -p ${rundir} ${lockdir}
+    chown condor:condor ${rundir} ${lockdir}
+
     # Check value of QUEUE_SUPER_USER_MAY_IMPERSONATE for HTCondor batch systems
     condor_ce_config_val -config 2>&1 | grep '02-ce-condor.conf' > /dev/null
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
If /var/run or /var/lock happen to be on tmpfs filesystems, then the subdirectories
needed at runtime for htcondor-ce do not exist.  This commit adds code to the start()
function in /etc/rc.d/init.d/condor-ce to ensure the RUN and LOCK directories
are created and assigned the correct ownership.

Bug: https://ticket.grid.iu.edu/30906