### PR TITLE
Fix OnExitHold to be set to expressions rather than their evaluated f…

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -61,13 +61,13 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
           ifThenElse(default_maxWallTime isnt null, strcat("Walltime == ", string(60*default_maxWallTime), " && CondorCE == 1"), \\
             "CondorCE == 1"))); \\
     copy_OnExitHold = "orig_OnExitHold"; \\
-    eval_set_OnExitHold = ifThenElse(orig_OnExitHold isnt null, orig_OnExitHold, false) || ifThenElse(minWalltime isnt null && RemoteWallClockTime isnt null, RemoteWallClockTime < 60*minWallTime, false); \\
+    set_OnExitHold = ifThenElse(orig_OnExitHold isnt null, orig_OnExitHold, false) || ifThenElse(minWalltime isnt null && RemoteWallClockTime isnt null, RemoteWallClockTime < 60*minWallTime, false); \\
     copy_OnExitHoldReason = "orig_OnExitHoldReason"; \\
-    eval_set_OnExitHoldReason = ifThenElse((orig_OnExitHold isnt null) && orig_OnExitHold, \\
+    set_OnExitHoldReason = ifThenElse((orig_OnExitHold isnt null) && orig_OnExitHold, \\
         ifThenElse(orig_OnExitHoldReason isnt null, orig_OnExitHoldReason, strcat("The on_exit_hold expression (", unparse(orig_OnExitHold), ") evaluated to TRUE.")), \\
         ifThenElse(minWalltime isnt null && RemoteWallClockTime isnt null && (RemoteWallClockTime < 60*minWallTime), strcat("The job's wall clock time, ", int(RemoteWallClockTime/60), "min, is less than the minimum specified by the job (", minWalltime, ")"), "Job held for unknown reason.")); \\
     copy_OnExitHoldSubCode = "orig_OnExitHoldSubCode"; \\
-    eval_set_OnExitHoldSubCode = ifThenElse((orig_OnExitHold isnt null) && orig_OnExitHold, \\
+    set_OnExitHoldSubCode = ifThenElse((orig_OnExitHold isnt null) && orig_OnExitHold, \\
         ifThenElse(orig_OnExitHoldSubCode isnt null, orig_OnExitHoldSubCode, 1), 42); \\
     set_AccountingGroupOSG = @accounting_group@; \\
     eval_set_AccountingGroup = AccountingGroupOSG; \\


### PR DESCRIPTION
orms. TJ noticed this when putting together the classad transform language. @bbockelm, could you review this since you did the original work on `OnExitHold`?