### PR TITLE
Move tmpfiles config to /usr/lib/tmpfiles.d (SOFTWARE-2444)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,4 +53,5 @@ install(FILES config/99-condor-ce.conf config/50-condor-ce-defaults.conf DESTINA
 install(FILES config/condor-ce config/condor-ce-collector DESTINATION ${SYSCONF_INSTALL_DIR}/sysconfig)
 install(FILES config/condor-ce-collector-generator.cron DESTINATION ${SYSCONF_INSTALL_DIR}/cron.d)
 install(FILES config/condor-ce-collector.logrotate  RENAME condor-ce-collector  DESTINATION ${SYSCONF_INSTALL_DIR}/logrotate.d)
-install(FILES config/condor-ce.conf config/condor-ce-collector.conf DESTINATION ${SYSCONF_INSTALL_DIR}/tmpfiles.d)
+install(FILES config/condor-ce.service config/condor-ce-collector.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
+install(FILES config/condor-ce.conf config/condor-ce-collector.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/tmpfiles.d)


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2444

Also a bonus commit that adds `%post`, `%preun`, and `%postun` sections that may relieve annoyances when updating the central collectors e.g. new config not taking effect because the service wasn't restarted.