### PR TITLE
Fix hold msg for jobs not picked up by the JR (SOFTWARE-2539)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -43,13 +43,12 @@ JOB_ROUTER_SOURCE_JOB_CONSTRAINT = (target.x509userproxysubject =!= UNDEFINED) &
 SYSTEM_PERIODIC_HOLD = (x509userproxysubject =?= UNDEFINED) || (x509UserProxyExpiration =?= UNDEFINED) || (time() > x509UserProxyExpiration) || (RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12) || ((JobStatus =?= 1 && CurrentTime - EnteredCurrentStatus > 1800) && RoutedToJobId is null && RoutedJob =!= true)
 
 SYSTEM_PERIODIC_HOLD_REASON = \
-   strcat("CE job in status ", JobStatus, \
-     " put on hold by SYSTEM_PERIODIC_HOLD due to ", \
+   strcat("HTCondor-CE held job due to ", \
      ifThenElse(isUndefined(x509userproxysubject) || isUndefined(x509UserProxyExpiration),  "missing user proxy.", \
        ifThenElse(time() > x509UserProxyExpiration, "expired user proxy.", \
          ifThenElse(RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12, \
            "invalid job universe.", \
-           "non-existent route in JOB_ROUTER_ENTRIES or route job limit." \
+           "no matching routes, route job limit, or route failure threshold; see 'HTCondor-CE Troubleshooting Guide'" \
          ) \
        ) \
      ) \

--- a/config/01-ce-router.conf.in
+++ b/config/01-ce-router.conf.in
@@ -39,13 +39,12 @@ JOB_ROUTER_SOURCE_JOB_CONSTRAINT = (target.x509userproxysubject =!= UNDEFINED) &
 SYSTEM_PERIODIC_HOLD = (x509userproxysubject =?= UNDEFINED) || (x509UserProxyExpiration =?= UNDEFINED) || (time() > x509UserProxyExpiration) || (RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12) || ((JobStatus =?= 1 && CurrentTime - EnteredCurrentStatus > 1800) && RoutedToJobId is null && RoutedJob =!= true)
 
 SYSTEM_PERIODIC_HOLD_REASON = \
-   strcat("CE job in status ", JobStatus, \
-     " put on hold by SYSTEM_PERIODIC_HOLD due to ", \
+   strcat("HTCondor-CE held job due to ", \
      ifThenElse(isUndefined(x509userproxysubject) || isUndefined(x509UserProxyExpiration),  "missing user proxy.", \
        ifThenElse(time() > x509UserProxyExpiration, "expired user proxy.", \
          ifThenElse(RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12, \
            "invalid job universe.", \
-           "non-existent route in JOB_ROUTER_ENTRIES or route job limit." \
+           "no matching routes, route job limit, or route failure threshold; see 'HTCondor-CE Troubleshooting Guide'" \
          ) \
        ) \
      ) \


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2539

There are at least 3 reasons that the Job Router will ignore idle jobs
in the Schedd for 30 min+:

1. Job did not match any available job routes
2. All potential job routes are full (i.e. reached MaxJobs)
3. Routed jobs are failing and throttling occurs; job submission rates
drop and the job router does not pick up new jobs until the failure
rate drops below the configured threshold

Rather than including them in a very long hold message, it makes more
sense to elaborate the reasons in our documentation.