### PR TITLE
Remove TotalSubmitProcs attribute in routed jobs

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -35,6 +35,7 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
                          (JobStatus == 1 && (time() - QDate) > 6*60);*/ \\
     delete_PeriodicRemove = true; \\
     delete_CondorCE = true; \\
+    delete_TotalSubmitProcs = true; \\
     set_RoutedJob = true; \\
     copy_environment = "orig_environment"; \\
     set_osg_environment = "@osg_environment@"; \\


### PR DESCRIPTION
TotalSubmitProcs is used in 8.5.7 for the for job totals in the new
condor_q formatting. If a user queues multiple jobs in their submit
file (resulting in multiple ProcIDs), the job router creates unique
ClusterIDs in the target SchedD for each ProcID. Each of these routed
jobs retains the TotalSubmitProcs from the original jobs and condor_q
reports erroneously large job totals.

@IainSteers encountered this issue and it's still being investigated since the target SchedD, if it's 8.5.7+, should be squashing the routed job's `TotalSubmitProcs` attribute. That being said, this change is defensive in nature and jobs without `TotalSubmitProcs` defined are unaffected.