### PR TITLE
condor_ce_info_status: safely handle bad data

### DIFF
--- a/src/condor_ce_info_status
+++ b/src/condor_ce_info_status
@@ -14,6 +14,17 @@ import htcondor
 
 import htcondorce.info_query
 
+# Add htcondor.param.get() to old versions of condor-python that don't have it
+try:
+    htcondor.param.get
+except AttributeError:
+    def _htcondor_param_get(key, default=None):
+        try:
+            return htcondor.param[key]
+        except KeyError:
+            return default
+    htcondor.param.get = _htcondor_param_get
+
 
 def formatResourceAdsTable(resources, width):
     """Create a table of resource information obtained from `resources`,

--- a/src/condor_ce_info_status
+++ b/src/condor_ce_info_status
@@ -55,9 +55,9 @@ def formatResourceAdsTable(resources, width):
     table += "\n"
     for resource in resources:
         catalog_entry = resource.catalog_entry
-        table += "\n" + format_str % (catalog_entry['Name'],
-                                      catalog_entry['CPUs'],
-                                      catalog_entry['Memory'],
+        table += "\n" + format_str % (catalog_entry.get('Name','???'),
+                                      catalog_entry.get('CPUs','???'),
+                                      catalog_entry.get('Memory','???'),
                                       catalog_entry.get('MaxWallTime', ''),
                                       ", ".join(list(catalog_entry.get('AllowedVOs', []))))
 

--- a/src/condor_ce_info_status
+++ b/src/condor_ce_info_status
@@ -56,7 +56,7 @@ def formatResourceAdsTable(resources, width):
     for resource in resources:
         catalog_entry = resource.catalog_entry
         table += "\n" + format_str % (catalog_entry.get('Name','???'),
-                                      catalog_entry.get('CPUs','???'),
+                                      catalog_entry.get('CPUs', catalog_entry.get('Cpus', '???')),
                                       catalog_entry.get('Memory','???'),
                                       catalog_entry.get('MaxWallTime', ''),
                                       ", ".join(list(catalog_entry.get('AllowedVOs', []))))

--- a/src/condor_ce_info_status
+++ b/src/condor_ce_info_status
@@ -14,17 +14,6 @@ import htcondor
 
 import htcondorce.info_query
 
-# Add htcondor.param.get() to old versions of condor-python that don't have it
-try:
-    htcondor.param.get
-except AttributeError:
-    def _htcondor_param_get(key, default=None):
-        try:
-            return htcondor.param[key]
-        except KeyError:
-            return default
-    htcondor.param.get = _htcondor_param_get
-
 
 def formatResourceAdsTable(resources, width):
     """Create a table of resource information obtained from `resources`,

--- a/src/htcondorce/info_query.py
+++ b/src/htcondorce/info_query.py
@@ -148,7 +148,7 @@ def filterResourceAds(constraints, resources):
         # would be 'closing over the loop variable'
         if attr == 'cpus':
             predicates.append(
-                lambda res: constraints['cpus'] <= res['CPUs'])
+                lambda res: constraints['cpus'] <= res.get('CPUs', res.get('Cpus')))
         elif attr == 'constrain':
             predicates.append(
                 lambda res: bool(evalExpressionStr(constraints['constrain'], res)))

--- a/src/htcondorce/info_query.py
+++ b/src/htcondorce/info_query.py
@@ -6,16 +6,6 @@ import htcondor
 import logging
 _logger = logging.getLogger(__name__)
 
-# Add htcondor.param.get() to old versions of condor-python that don't have it
-try:
-    htcondor.param.get
-except AttributeError:
-    def _htcondor_param_get(key, default=None):
-        try:
-            return htcondor.param[key]
-        except KeyError:
-            return default
-    htcondor.param.get = _htcondor_param_get
 
 
 class ResourceAd(classad.ClassAd):


### PR DESCRIPTION
Don't crash if entries are received from the collector with missing values for `CPUs` or `Memory`. Also handle if the attribute for `CPUs` is actually `Cpus`. This is for SOFTWARE-2185.