### PR TITLE
Do not catch eval_set_ in JOB_ROUTER_ENTRIES (SOFTWARE-2581)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ configure_file (
 )
 
 install(PROGRAMS src/condor-ce src/condor-ce-collector DESTINATION ${SYSCONF_INSTALL_DIR}/rc.d/init.d)
-install(PROGRAMS src/condor_ce_startup src/condor_ce_startup_internal src/condor_ce_env_bootstrap src/condor_ce_client_env_bootstrap src/condor_ce_router_defaults src/osg-wrapper src/condor_ce_jobmetrics src/condor_ce_metric src/condor_ce_view src/bdii/condor_ce_bdii_generate_glue1.py src/bdii/condor_ce_bdii_generate_glue2.py src/gratia_cleanup.py DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce)
+install(PROGRAMS src/condor_ce_startup src/verify_ce_config.py src/condor_ce_startup_internal src/condor_ce_env_bootstrap src/condor_ce_client_env_bootstrap src/condor_ce_router_defaults src/osg-wrapper src/condor_ce_jobmetrics src/condor_ce_metric src/condor_ce_view src/bdii/condor_ce_bdii_generate_glue1.py src/bdii/condor_ce_bdii_generate_glue2.py src/gratia_cleanup.py DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce)
 install(PROGRAMS src/condor_ce_config_generator src/condor_ce_config_val src/condor_ce_history src/condor_ce_hold src/condor_ce_info_status src/condor_ce_q src/condor_ce_qedit src/condor_ce_release src/condor_ce_rm src/condor_ce_submit src/condor_ce_version src/condor_ce_reconfig src/condor_ce_router_q src/condor_ce_status src/condor_ce_reschedule src/condor_ce_run src/condor_ce_trace src/condor_ce_ping src/condor_ce_off src/condor_ce_on src/condor_ce_restart src/condor_ce_job_router_info src/condor_ce_host_network_check DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(FILES src/htcondorce/__init__.py src/htcondorce/web_utils.py src/htcondorce/web.py src/htcondorce/rrd.py src/htcondorce/tools.py src/htcondorce/info_query.py DESTINATION ${PYTHON_SITELIB}/htcondorce)
 

--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -414,6 +414,7 @@ fi
 %{_datadir}/condor-ce/condor_ce_client_env_bootstrap
 %{_datadir}/condor-ce/condor_ce_startup
 %{_datadir}/condor-ce/condor_ce_startup_internal
+%{_datadir}/condor-ce/verify_ce_config.py*
 
 %{_bindir}/condor_ce_config_val
 %{_bindir}/condor_ce_hold

--- a/src/condor_ce_startup
+++ b/src/condor_ce_startup
@@ -21,51 +21,8 @@ if [[ "$1" != "collector" ]]; then
 Please verify that '$CONFIG_KNOB=.*' is set in your HTCondor configuration."
     fi
 
-    # Verify that the HTCondor Python bindings are in the PYTHONPATH
-    python -c "import htcondor; import classad" &> /dev/null || \
-        fail 6 "Could not load HTCondor Python bindings. \
-Please ensure that the 'htcondor' and 'classad' are in your PYTHONPATH"
-
-    # Verify job routes. classad.parseAds() ignores malformed ads so we have to compare
-    # the unparsed string to the parsed string, counting the number of ads by proxy:
-    # the number of opening square brackets, "["
-    for ATTR in 'JOB_ROUTER_DEFAULTS' 'JOB_ROUTER_ENTRIES'; do
-        python -c "import os, htcondor, classad;\
-entries = htcondor.param[\"$ATTR\"];\
-ads = classad.parseAds(entries);\
-exit() if entries.count('[') == ''.join([str(x) for x in ads]).count('[') else exit(1)" &> /dev/null || \
-            fail 6 "Could not read $ATTR in the HTCondor CE configuration. Please verify syntax correctness."
-    done
-
-    JOB_ROUTER_DEFAULTS=`/usr/share/condor-ce/condor_ce_router_defaults`
-    JOB_ROUTER_ENTRIES=`condor_ce_config_val JOB_ROUTER_ENTRIES`
-
-    # Ensure that users don't set_ attributes that are eval_set in the JOB_ROUTER_DEFAULTS
-    for attr in `sed -n 's/.*eval_set_\([a-zA-Z_]*\).*/\1/p' <<< "$JOB_ROUTER_DEFAULTS"`; do
-        grep "set_$attr" <<< "$JOB_ROUTER_ENTRIES" &> /dev/null && \
-            echo -e "\nWARNING: set_$attr in the JOB_ROUTER_ENTRIES will be overriden \
-by the JOB_ROUTER DEFAULTS. Use eval_set_$attr instead."
-    done
-
-    # Ensure that users don't set the job environment in the Job Router
-    tr ';' '\n' <<< "$JOB_ROUTER_ENTRIES" | egrep '[][ ]*[a-zA-Z]*_environment' &> /dev/null && \
-        fail 6 "Do not use the Job Router to set the environment. Place variables under \
-[Local Settings] in /etc/osg/config.d/40-localsettings.ini"
-
-    # Ensure that users don't eval_set_ default attributes in the ENTRIES since it may happen
-    # after the expressions containing them get evaluated in the DEFAULTS
-    for attr in `sed -n 's/.*\(default_[a-zA-Z_]*\).*/\1/p' <<< "$JOB_ROUTER_DEFAULTS" | sort | uniq`; do
-
-        grep "eval_set_$attr" <<< "$JOB_ROUTER_ENTRIES" &> /dev/null && \
-            echo -e "\nWARNING: eval_set_$attr in the JOB_ROUTER_ENTRIES \
-may not have any effect. Use set_$attr instead."
-    done
-
-    # Check if osg-configure has been run
-    OSG_CONFIGURED=`condor_ce_config_val OSG_CONFIGURED | tr '[:upper:]' '[:lower:]'`
-    [ "$OSG_CONFIGURED" != 'true' ] && echo -e "\nWARNING: osg-configure has not been run, degrading the functionality \
-of the CE. Please run 'osg-configure -c' and restart condor-ce."
-
+    # Verify configuration using the python bindings
+    python /usr/share/condor-ce/verify_ce_config.py || exit 6
 else
     shift
 fi

--- a/src/verify_ce_config.py
+++ b/src/verify_ce_config.py
@@ -45,7 +45,7 @@ for entry in JOB_ROUTER_CONFIG['JOB_ROUTER_ENTRIES']:
             + " Use the 'eval_set_' prefix instead."
 
     # Ensure that users don't set the job environment in the Job Router
-    if [x for x in entry.keys() if x.endswith('environment')]:
+    if any(x.endswith('environment') for x in entry.keys()):
         sys.exit("ERROR: Do not use the Job Router to set the environment. Place variables under " +\
                  "[Local Settings] in /etc/osg/config.d/40-localsettings.ini")
 

--- a/src/verify_ce_config.py
+++ b/src/verify_ce_config.py
@@ -16,15 +16,16 @@ except ImportError:
              "Please ensure that the 'htcondor' and 'classad' are in your PYTHONPATH")
 
 # Create dict whose values are lists of ads specified in the relevant JOB_ROUTER_* variables
-JOB_ROUTER_CONFIG = dict((x, [x for x in classad.parseAds(htcondor.param[x])])
-                         for x in ['JOB_ROUTER_DEFAULTS', 'JOB_ROUTER_ENTRIES'])
-    
+JOB_ROUTER_CONFIG = {}
+for attr in ['JOB_ROUTER_DEFAULTS', 'JOB_ROUTER_ENTRIES']:
+    ads = classad.parseAds(htcondor.param[attr])
+    JOB_ROUTER_CONFIG[attr] = list(ads) # store the ads (iterating through ClassAdStringIterator consumes them)
+
 # Verify job routes. classad.parseAds() ignores malformed ads so we have to compare the unparsed string to the
 # parsed string, counting the number of ads by proxy: the number of opening square brackets, "["
 for attr, ads in JOB_ROUTER_CONFIG.items():
     if htcondor.param[attr].count('[') != len(ads):
         sys.exit("ERROR: Could not read %s in the HTCondor CE configuration. Please verify syntax correctness" % attr)
-
 
 # Find all eval_set_ attributes in the JOB_ROUTER_DEFAULTS
 EVAL_SET_DEFAULTS = set([x.lstrip('eval_') for x in JOB_ROUTER_CONFIG['JOB_ROUTER_DEFAULTS'][0].keys()

--- a/src/verify_ce_config.py
+++ b/src/verify_ce_config.py
@@ -1,0 +1,64 @@
+#!/bin/env python
+
+"""
+Verify HTCondor-CE configuration before service startup
+"""
+
+import re
+import sys
+
+# Verify that the HTCondor Python bindings are in the PYTHONPATH
+try:
+    import classad
+    import htcondor
+except ImportError:
+    sys.exit("ERROR: Could not load HTCondor Python bindings. " + \
+             "Please ensure that the 'htcondor' and 'classad' are in your PYTHONPATH")
+
+# Create dict whose values are lists of ads specified in the relevant JOB_ROUTER_* variables
+JOB_ROUTER_CONFIG = dict((x, [x for x in classad.parseAds(htcondor.param[x])])
+                         for x in ['JOB_ROUTER_DEFAULTS', 'JOB_ROUTER_ENTRIES'])
+    
+# Verify job routes. classad.parseAds() ignores malformed ads so we have to compare the unparsed string to the
+# parsed string, counting the number of ads by proxy: the number of opening square brackets, "["
+for attr, ads in JOB_ROUTER_CONFIG.items():
+    if htcondor.param[attr].count('[') != len(ads):
+        sys.exit("ERROR: Could not read %s in the HTCondor CE configuration. Please verify syntax correctness" % attr)
+
+
+# Find all eval_set_ attributes in the JOB_ROUTER_DEFAULTS
+EVAL_SET_DEFAULTS = set([x.lstrip('eval_') for x in JOB_ROUTER_CONFIG['JOB_ROUTER_DEFAULTS'][0].keys()
+                         if x.startswith('eval_set_')])
+
+# Find all default_ attributes used in expressions in the JOB_ROUTER_DEFAULTS
+DEFAULT_ATTR = set([re.sub(r'.*(default_\w*).*', 'eval_set_\\1', str(x))
+                    for x in JOB_ROUTER_CONFIG['JOB_ROUTER_DEFAULTS'][0].values()
+                    if isinstance(x, classad.ExprTree) and str(x).find('default_') != -1])
+
+for entry in JOB_ROUTER_CONFIG['JOB_ROUTER_ENTRIES']:
+    # Warn users if they've set_ attributes that would be overriden by eval_set in the JOB_ROUTER_DEFAULTS
+    overriden_attr = EVAL_SET_DEFAULTS.intersection(set(entry.keys()))
+    if overriden_attr:
+        print "WARNING: %s in JOB_ROUTER_ENTRIES will be overriden by the JOB_ROUTER_DEFAULTS." \
+            % ', '.join(overriden_attr) \
+            + " Use the 'eval_set_' prefix instead."
+
+    # Ensure that users don't set the job environment in the Job Router
+    if [x for x in entry.keys() if x.endswith('environment')]:
+        sys.exit("ERROR: Do not use the Job Router to set the environment. Place variables under " +\
+                 "[Local Settings] in /etc/osg/config.d/40-localsettings.ini")
+
+    # Warn users about eval_set_ default attributes in the ENTRIES since their
+    # evaluation may occur after the eval_set_ expressions containg them in the
+    # JOB_ROUTER_DEFAULTS
+    no_effect_attr = DEFAULT_ATTR.intersection(set([x for x in entry.keys() if x.startswith('eval_set_')]))
+    if no_effect_attr:
+        print "WARNING: %s in JOB_ROUTER_ENTRIES " % ', '.join(no_effect_attr) + \
+            "may not have any effect. Use the 'set_' prefix instead."
+
+# Warn users if osg-configure has not been run
+try:
+    htcondor.param['OSG_CONFIGURED']
+except KeyError:
+    print "WARNING: osg-configure has not been run, degrading the functionality " + \
+        "of the CE. Please run 'osg-configure -c' and restart condor-ce."


### PR DESCRIPTION
We want to catch set_ATTR lines in JOB_ROUTER_ENTRIES for ATTR that
are eval_set_ATTR in JOB_ROUTER_DEFAULTS because they end up as
NOOPs. We were accidentally catching eval_set_ATTR statements in
JOB_ROUTER_ENTRIES, which we recommend against because they overwrite
their respective expressions in JOB_ROUTER_DEFAULTS but are
ultimately allowed.