### PR TITLE
Respect RequestCpus of incoming jobs (SOFTWARE-2598)

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -53,7 +53,11 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     eval_set_RequestMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
     eval_set_remote_queue = ifThenElse(batch_queue isnt undefined, batch_queue, ifThenElse(queue isnt undefined, queue, ifThenElse(default_queue isnt undefined, default_queue, ""))); \\
     /* HTCondor uses RequestCpus; blahp uses SMPGranularity and NodeNumber.  Default is 1 core. */ \\
-    eval_set_RequestCpus = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
+    eval_set_RequestCpus = ifThenElse(xcount isnt undefined, xcount, \\
+        ifThenElse(TARGET.RequestCpus isnt undefined, \\
+            ifThenElse(RequestCpus > 1, RequestCpus, \\
+                ifThenElse(default_xcount isnt undefined, default_xcount, 1)), \\
+            ifThenElse(default_xcount isnt undefined, default_xcount, 1))); \\
     eval_set_remote_SMPGranularity = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
     eval_set_remote_NodeNumber = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
     /* If remote_cerequirements is a string, BLAH will parse it as an expression before examining it */ \\


### PR DESCRIPTION
If a user requests CPU via condor's standard "request_cpu" submit
attribute, we should respect it. We check if the value is 1 because
newer versions of condor_submit automatically set "RequestCpus =
1". The one limitation of this method is that users cannot submit jobs
with "request_cpus = 1" and have that respected if the admin has set a
default_xcount.

https://jira.opensciencegrid.org/browse/SOFTWARE-2598