### PR TITLE
Fix assignment of RequestCpus (SOFTWARE-2598)

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -53,9 +53,10 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     eval_set_RequestMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
     eval_set_remote_queue = ifThenElse(batch_queue isnt undefined, batch_queue, ifThenElse(queue isnt undefined, queue, ifThenElse(default_queue isnt undefined, default_queue, ""))); \\
     /* HTCondor uses RequestCpus; blahp uses SMPGranularity and NodeNumber.  Default is 1 core. */ \\
+    copy_RequestCpus = "orig_RequestCpus"; \\
     eval_set_RequestCpus = ifThenElse(xcount isnt undefined, xcount, \\
-        ifThenElse(TARGET.RequestCpus isnt undefined, \\
-            ifThenElse(RequestCpus > 1, RequestCpus, \\
+        ifThenElse(orig_RequestCpus isnt undefined, \\
+            ifThenElse(orig_RequestCpus > 1, orig_RequestCpus, \\
                 ifThenElse(default_xcount isnt undefined, default_xcount, 1)), \\
             ifThenElse(default_xcount isnt undefined, default_xcount, 1))); \\
     eval_set_remote_SMPGranularity = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\


### PR DESCRIPTION
eval_set_<attr> expressions don't like it if they have <attr> within them. Tested the fix and `RequestCpus` is properly set on the routed job.