### PR TITLE
Do not explicitly disable VOMS credential check.

### DIFF
--- a/src/condor_ce_env_bootstrap
+++ b/src/condor_ce_env_bootstrap
@@ -2,7 +2,6 @@
 
 # Configuration for LCMAPS
 export LLGT_LOG_IDENT=htcondor-ce
-export LLGT_VOMS_DISABLE_CREDENTIAL_CHECK=1
 export LCMAPS_DB_FILE=/etc/lcmaps.db
 export LCMAPS_POLICY_NAME=authorize_only
 #level 0: no messages, 1: errors, 2: also warnings, 3: also notices,


### PR DESCRIPTION
Instead, we'll depend on the default value that is compiled in to LCMAPS.  SOFTWARE-2633