### PR TITLE
Add WholeNodeWanted ClassAd expression to request whole-node jobs

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -50,15 +50,23 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     set_requirements = True; \\
     /* Note default memory request of 2GB */ \\
     /* Note yet another nested condition allow pass attributes (maxMemory,xcount,jobtype,queue) via gWMS Factory described within ClassAd */ \\
-    eval_set_RequestMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
+    eval_set_OriginalMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
+    set_JOB_GLIDEIN_Memory = "$$(TotalMemory:0)"; \\
+    set_JobMemory = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Memory)*95/100 : OriginalMemory; \\
+    set_RequestMemory = ifThenElse(WholeNodeWanted is true, !isUndefined(TotalMemory) ? TotalMemory*95/100 : JobMemory, OriginalMemory); \\
     eval_set_remote_queue = ifThenElse(batch_queue isnt undefined, batch_queue, ifThenElse(queue isnt undefined, queue, ifThenElse(default_queue isnt undefined, default_queue, ""))); \\
     /* HTCondor uses RequestCpus; blahp uses SMPGranularity and NodeNumber.  Default is 1 core. */ \\
     copy_RequestCpus = "orig_RequestCpus"; \\
-    eval_set_RequestCpus = ifThenElse(xcount isnt undefined, xcount, \\
+    eval_set_OriginalCpus = ifThenElse(xcount isnt undefined, xcount, \\
         ifThenElse(orig_RequestCpus isnt undefined, \\
             ifThenElse(orig_RequestCpus > 1, orig_RequestCpus, \\
                 ifThenElse(default_xcount isnt undefined, default_xcount, 1)), \\
             ifThenElse(default_xcount isnt undefined, default_xcount, 1))); \\
+    set_GlideinCpusIsGood = !isUndefined(MATCH_EXP_JOB_GLIDEIN_Cpus) && (int(MATCH_EXP_JOB_GLIDEIN_Cpus) isnt error); \\
+    set_JOB_GLIDEIN_Cpus = "$$(TotalCpus:0)"; \\
+    set_JobIsRunning = (JobStatus =!= 1) && (JobStatus =!= 5) && GlideinCpusIsGood; \\
+    set_JobCpus = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus; \\
+    set_RequestCpus = ifThenElse(WholeNodeWanted is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\
     eval_set_remote_SMPGranularity = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
     eval_set_remote_NodeNumber = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
     /* If remote_cerequirements is a string, BLAH will parse it as an expression before examining it */ \\


### PR DESCRIPTION
When WholeNodeWanted=true, request the following resources for the job:
- TotalCpus of the worker
- 95% of TotalMemory

Implements the method from "Getting To Multicore: Resizing jobs in CMS" by @bbockelm. HTCondor Week 2016.
https://research.cs.wisc.edu/htcondor/HTCondorWeek2016/presentations/ThuBockelman_ResizableJobs.pdf