### PR TITLE
Drop boost/cmake build requires

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -185,9 +185,6 @@ Provides:  condor-ce-bosco = %{version}
 Group: Applications/System
 Summary: Client-side tools for submission to HTCondor-CE
 
-BuildRequires: boost-devel
-BuildRequires: cmake
-
 # Note the strange requirements (base package is not required!
 # Point is to be able to submit jobs without installing the server.
 Requires: condor


### PR DESCRIPTION
We no longer build classad functions