### PR TITLE
Use WantWholeNode to match existing factory naming convention

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -53,7 +53,7 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     eval_set_OriginalMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
     set_JOB_GLIDEIN_Memory = "$$(TotalMemory:0)"; \\
     set_JobMemory = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Memory)*95/100 : OriginalMemory; \\
-    set_RequestMemory = ifThenElse(WholeNodeWanted is true, !isUndefined(TotalMemory) ? TotalMemory*95/100 : JobMemory, OriginalMemory); \\
+    set_RequestMemory = ifThenElse(WantWholeNode is true, !isUndefined(TotalMemory) ? TotalMemory*95/100 : JobMemory, OriginalMemory); \\
     eval_set_remote_queue = ifThenElse(batch_queue isnt undefined, batch_queue, ifThenElse(queue isnt undefined, queue, ifThenElse(default_queue isnt undefined, default_queue, ""))); \\
     /* HTCondor uses RequestCpus; blahp uses SMPGranularity and NodeNumber.  Default is 1 core. */ \\
     copy_RequestCpus = "orig_RequestCpus"; \\
@@ -66,7 +66,7 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     set_JOB_GLIDEIN_Cpus = "$$(TotalCpus:0)"; \\
     set_JobIsRunning = (JobStatus =!= 1) && (JobStatus =!= 5) && GlideinCpusIsGood; \\
     set_JobCpus = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus; \\
-    set_RequestCpus = ifThenElse(WholeNodeWanted is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\
+    set_RequestCpus = ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\
     eval_set_remote_SMPGranularity = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
     eval_set_remote_NodeNumber = ifThenElse(xcount isnt undefined, xcount, ifThenElse(default_xcount isnt undefined, default_xcount, 1)); \\
     /* If remote_cerequirements is a string, BLAH will parse it as an expression before examining it */ \\


### PR DESCRIPTION
OSG factory operations has an existing convention of "Want{Item}", e.g. WantSingularity.

For whole node support added in #142, change flag from WholeNodeWanted to WantWholeNode to match existing factory naming convention.