### PR TITLE
Bring back cmake

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -185,6 +185,8 @@ Provides:  condor-ce-bosco = %{version}
 Group: Applications/System
 Summary: Client-side tools for submission to HTCondor-CE
 
+BuildRequires: cmake
+
 # Note the strange requirements (base package is not required!
 # Point is to be able to submit jobs without installing the server.
 Requires: condor


### PR DESCRIPTION
boost-devel and cmake removed in 3eb0476 but we still need the
latter. Passed our CI tests because we install cmake directly.