### PR TITLE
Save the number of CPUs allocated at last match

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -63,7 +63,7 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
                 ifThenElse(default_xcount isnt undefined, default_xcount, 1)), \\
             ifThenElse(default_xcount isnt undefined, default_xcount, 1))); \\
     set_GlideinCpusIsGood = !isUndefined(MATCH_EXP_JOB_GLIDEIN_Cpus) && (int(MATCH_EXP_JOB_GLIDEIN_Cpus) isnt error); \\
-    set_JOB_GLIDEIN_Cpus = ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\
+    set_JOB_GLIDEIN_Cpus = $$(ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus)); \\
     set_JobIsRunning = (JobStatus =!= 1) && (JobStatus =!= 5) && GlideinCpusIsGood; \\
     set_JobCpus = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus; \\
     set_RequestCpus = ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -63,7 +63,7 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
                 ifThenElse(default_xcount isnt undefined, default_xcount, 1)), \\
             ifThenElse(default_xcount isnt undefined, default_xcount, 1))); \\
     set_GlideinCpusIsGood = !isUndefined(MATCH_EXP_JOB_GLIDEIN_Cpus) && (int(MATCH_EXP_JOB_GLIDEIN_Cpus) isnt error); \\
-    set_JOB_GLIDEIN_Cpus = "$$(TotalCpus:0)"; \\
+    set_JOB_GLIDEIN_Cpus = ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\
     set_JobIsRunning = (JobStatus =!= 1) && (JobStatus =!= 5) && GlideinCpusIsGood; \\
     set_JobCpus = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus; \\
     set_RequestCpus = ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -63,7 +63,7 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
                 ifThenElse(default_xcount isnt undefined, default_xcount, 1)), \\
             ifThenElse(default_xcount isnt undefined, default_xcount, 1))); \\
     set_GlideinCpusIsGood = !isUndefined(MATCH_EXP_JOB_GLIDEIN_Cpus) && (int(MATCH_EXP_JOB_GLIDEIN_Cpus) isnt error); \\
-    set_JOB_GLIDEIN_Cpus = $$(ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus)); \\
+    set_JOB_GLIDEIN_Cpus = "$$(ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus))"; \\
     set_JobIsRunning = (JobStatus =!= 1) && (JobStatus =!= 5) && GlideinCpusIsGood; \\
     set_JobCpus = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus; \\
     set_RequestCpus = ifThenElse(WantWholeNode is true, !isUndefined(TotalCpus) ? TotalCpus : JobCpus, OriginalCpus); \\


### PR DESCRIPTION
When a whole node job is matched, we need to save the number of cpus
so that accounting systems can pick up how many cpus where actually 
used by a job.