### PR TITLE
Pass OriginalMemory variable through GAHP

### DIFF
--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -51,6 +51,8 @@ JOB_ROUTER_DEFAULTS_GENERATED = \\
     /* Note default memory request of 2GB */ \\
     /* Note yet another nested condition allow pass attributes (maxMemory,xcount,jobtype,queue) via gWMS Factory described within ClassAd */ \\
     eval_set_OriginalMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
+    /* Duplicate OriginalMemory expression and add remote_ prefix. This passes the attribute from gridmanager to BLAHP. */ \\
+    eval_set_remote_OriginalMemory = ifThenElse(maxMemory isnt undefined, maxMemory, ifThenElse(default_maxMemory isnt undefined, default_maxMemory, 2000)); \\
     set_JOB_GLIDEIN_Memory = "$$(TotalMemory:0)"; \\
     set_JobMemory = JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Memory)*95/100 : OriginalMemory; \\
     set_RequestMemory = ifThenElse(WantWholeNode is true, !isUndefined(TotalMemory) ? TotalMemory*95/100 : JobMemory, OriginalMemory); \\


### PR DESCRIPTION
Hi @djw8605, @brianhlin, and @bbockelm,

Troubleshooting failed jobs, I found that the memory requirements were not passing through BLAHP to the local scheduler (pbs_submit.sh -> SLURM).

When passing a job to a GAHP server, gridmanager [copies](https://github.com/htcondor/htcondor/blob/f7ac6cce/src/condor_gridmanager/infnbatchjob.cpp#L1381-L1396) a limited list of attributes, which includes RequestMemory.

With the whole node changes (#142), RequestMemory is now an expression that includes OriginalMemory. But, OriginalMemory is not passed along by gridmanager, so BLAHP cannot evaluate RequestMemory.

Please consider this PR as an ugly proof-of-concept. It appears to get RequestMemory passed to the local scheduler, but I'd appreciate your help on making it cleaner.

Regards,
John