### PR TITLE
Do not hold running jobs with expired proxy (SOFTWARE-2803)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -37,10 +37,10 @@ JOB_ROUTER_SOURCE_JOB_CONSTRAINT = (target.x509userproxysubject =!= UNDEFINED) &
 
 # Put jobs on hold if they meet any of the following requirements
 # 1. Is missing a proxy subject or proxy expiration date.
-# 2. Has an expired proxy
+# 2. Has an expired proxy and is not running
 # 3. It has not been routed by the CE and is not a standard, vanilla, scheduler, or local job.
 # 4. It has not been routed by the CE and has been idle for 30+ min
-SYSTEM_PERIODIC_HOLD = (x509userproxysubject =?= UNDEFINED) || (x509UserProxyExpiration =?= UNDEFINED) || (time() > x509UserProxyExpiration) || (RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12) || ((JobStatus =?= 1 && CurrentTime - EnteredCurrentStatus > 1800) && RoutedToJobId is null && RoutedJob =!= true)
+SYSTEM_PERIODIC_HOLD = (x509userproxysubject =?= UNDEFINED) || (x509UserProxyExpiration =?= UNDEFINED) || (time() > x509UserProxyExpiration && JobStatus =!= 2) || (RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12) || ((JobStatus =?= 1 && CurrentTime - EnteredCurrentStatus > 1800) && RoutedToJobId is null && RoutedJob =!= true)
 
 SYSTEM_PERIODIC_HOLD_REASON = \
    strcat("HTCondor-CE held job due to ", \

--- a/config/01-ce-router.conf.in
+++ b/config/01-ce-router.conf.in
@@ -33,10 +33,10 @@ JOB_ROUTER_SOURCE_JOB_CONSTRAINT = (target.x509userproxysubject =!= UNDEFINED) &
 
 # Put jobs on hold if they meet any of the following requirements
 # 1. Is missing a proxy subject or proxy expiration date.
-# 2. Has an expired proxy
+# 2. Has an expired proxy and is not running
 # 3. It has not been routed by the CE and is not a standard, vanilla, scheduler, or local job.
 # 4. It has not been routed by the CE and has been idle for 30+ min
-SYSTEM_PERIODIC_HOLD = (x509userproxysubject =?= UNDEFINED) || (x509UserProxyExpiration =?= UNDEFINED) || (time() > x509UserProxyExpiration) || (RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12) || ((JobStatus =?= 1 && CurrentTime - EnteredCurrentStatus > 1800) && RoutedToJobId is null && RoutedJob =!= true)
+SYSTEM_PERIODIC_HOLD = (x509userproxysubject =?= UNDEFINED) || (x509UserProxyExpiration =?= UNDEFINED) || (time() > x509UserProxyExpiration && JobStatus =!= 2) || (RoutedBy is null && JobUniverse =!= 1 && JobUniverse =!= 5 && JobUniverse =!= 7 && JobUniverse =!= 12) || ((JobStatus =?= 1 && CurrentTime - EnteredCurrentStatus > 1800) && RoutedToJobId is null && RoutedJob =!= true)
 
 SYSTEM_PERIODIC_HOLD_REASON = \
    strcat("HTCondor-CE held job due to ", \


### PR DESCRIPTION
Address issue reported in SOFTWARE-2803:
* The proxy in the spool directory on the CE is not necessarily the one used to communicate between the factory and the CE.  An expired proxy can be subsequently updated.
* The glideinWMS pilot only needs to do a GSI auth to establish an initial connection to the collector - afterward, it uses the established HTCondor security session between startd and collector.