### PR TITLE
fix when a startjob first stops the last job in a master

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -2,8 +2,8 @@
 #define gitrev osg
 
 Name: htcondor-ce
-Version: 3.0.0
-Release: 2%{?gitrev:.%{gitrev}git}%{?dist}
+Version: 3.0.1
+Release: 1%{?gitrev:.%{gitrev}git}%{?dist}
 Summary: A framework to run HTCondor as a CE
 BuildArch: noarch
 
@@ -491,7 +491,7 @@ fi
 %attr(1777,root,root) %dir %{_localstatedir}/lib/gratia/condorce_data
 
 %changelog
-* Mon Jul 31 2017 Dave Dykstra <dwd@fnal.gov> - 3.0.0-2
+* Tue Aug 01 2017 Dave Dykstra <dwd@fnal.gov> - 3.0.1-1
 - Fix loss of job audit info when a new job implicitly stopped a previous
   job that was the last one in a master slot (SOFTWARE-2788).
 

--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -3,7 +3,7 @@
 
 Name: htcondor-ce
 Version: 3.0.0
-Release: 1%{?gitrev:.%{gitrev}git}%{?dist}
+Release: 2%{?gitrev:.%{gitrev}git}%{?dist}
 Summary: A framework to run HTCondor as a CE
 BuildArch: noarch
 
@@ -491,6 +491,10 @@ fi
 %attr(1777,root,root) %dir %{_localstatedir}/lib/gratia/condorce_data
 
 %changelog
+* Mon Jul 31 2017 Dave Dykstra <dwd@fnal.gov> - 3.0.0-2
+- Fix loss of job audit info when a new job implicitly stopped a previous
+  job that was the last one in a master slot (SOFTWARE-2788).
+
 * Thu Jul 27 2017 Dave Dykstra <dwd@fnal.gov> - 3.0.0-1
 - Add the audit_payloads function.  This logs the starting and stopping of
   all payloads that were started from pilot systems based on condor.

--- a/src/audit_payloads.py
+++ b/src/audit_payloads.py
@@ -136,7 +136,8 @@ def startjob(info):
                 return
             # first stop the existing job, the slot is being reused
             stopjob(info)
-    else:
+	    # this may have removed the last job in thismaster, check again
+    if idx not in runningmasters:
         # new master
         now = time.time()
         thismaster = (now, {})


### PR DESCRIPTION
This fixes a bug I found that was losing a small percentage of stop messages.