### PR TITLE
Create required dirs on install (SOFTWARE-2806)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ endif()
 set(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/share" CACHE PATH "Base directory for files which go to share/")
 set(SYSCONF_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/etc" CACHE PATH "Base directory for files which go to etc/")
 set(STATE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/var" CACHE PATH "Base directory for files which go to var/")
-set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Base directory for files which go to lib/")
 
 include(FindPythonInterp)
 execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib().replace('/usr', '${CMAKE_INSTALL_PREFIX}', 1))" OUTPUT_VARIABLE DETECTED_PYTHON_SITELIB OUTPUT_STRIP_TRAILING_WHITESPACE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 set(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/share" CACHE PATH "Base directory for files which go to share/")
 set(SYSCONF_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/etc" CACHE PATH "Base directory for files which go to etc/")
+set(STATE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/var" CACHE PATH "Base directory for files which go to var/")
 set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Base directory for files which go to lib/")
 
 include(FindPythonInterp)
@@ -139,6 +140,26 @@ install(FILES
   contrib/bdii/50-ce-bdii-defaults.conf
   DESTINATION
   ${SYSCONF_INSTALL_DIR}/condor/config.d)
+
+set(HTCONDORCE_DIRS ${STATE_INSTALL_DIR}/run/condor-ce ${STATE_INSTALL_DIR}/log/condor-ce
+  ${STATE_INSTALL_DIR}/log/condor-ce/user ${STATE_INSTALL_DIR}/lib/condor-ce ${STATE_INSTALL_DIR}/lib/condor-ce/spool
+  ${STATE_INSTALL_DIR}/lib/condor-ce/spool/ceview ${STATE_INSTALL_DIR}/lib/condor-ce/spool/ceview/vos
+  ${STATE_INSTALL_DIR}/lib/condor-ce/spool/ceview/metrics ${STATE_INSTALL_DIR}/lib/condor-ce/execute
+  ${STATE_INSTALL_DIR}/lock/condor-ce ${STATE_INSTALL_DIR}/lock/condor-ce/user
+  ${STATE_INSTALL_DIR}/lib/gratia/condorce_data ${SYSCONF_INSTALL_DIR}/logrotate.d)
+
+foreach(dir IN ITEMS ${HTCONDORCE_DIRS})
+  install(DIRECTORY DESTINATION ${dir})
+  install(CODE "execute_process(COMMAND chown condor:condor ${dir})")
+endforeach(dir)
+
+set(STICKY_HTCONDORCE_DIRS ${STATE_INSTALL_DIR}/log/condor-ce/user ${STATE_INSTALL_DIR}/lock/condor-ce/user
+  ${SYSCONF_INSTALL_DIR}/logrotate.d)
+
+foreach(sticky_dir IN ITEMS ${STICKY_HTCONDORCE_DIRS})
+  install(CODE "execute_process(COMMAND chmod 1777 ${sticky_dir})")
+endforeach(sticky_dir)
+
 install(FILES config/ce-status.cpf config/pilot-status.cpf DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce)
 install(FILES templates/index.html templates/vos.html templates/metrics.html
 	templates/health.html templates/header.html templates/pilots.html DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce/templates)

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -177,7 +177,7 @@ Conflicts: %{name}
 %setup -q
 
 %build
-%cmake -DHTCONDORCE_VERSION=%{version} -DCMAKE_INSTALL_LIBDIR=%{_libdir} -DPYTHON_SITELIB=%{python_sitelib}
+%cmake -DHTCONDORCE_VERSION=%{version} -DSTATE_INSTALL_DIR=%{_localstatedir} -DCMAKE_INSTALL_LIBDIR=%{_libdir}  -DPYTHON_SITELIB=%{python_sitelib}
 make %{?_smp_mflags}
 
 %install
@@ -190,21 +190,6 @@ rm $RPM_BUILD_ROOT%{_unitdir}/condor-ce{,-collector}.service
 rm $RPM_BUILD_ROOT%{_tmpfilesdir}/condor-ce{,-collector}.conf
 %endif
 
-# Directories necessary for HTCondor-CE files
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/run/condor-ce
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/log/condor-ce
-install -m 1777 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/log/condor-ce/user
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/condor-ce
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/condor-ce/spool
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/condor-ce/spool/ceview
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/condor-ce/spool/ceview/vos
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/condor-ce/spool/ceview/metrics
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/condor-ce/execute
-install -m 0755 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lock/condor-ce
-install -m 1777 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lock/condor-ce/user
-install -m 1777 -d -p $RPM_BUILD_ROOT/%{_localstatedir}/lib/gratia/condorce_data
-
-# Don't build bdii sub-package for the OSG
 %if 0%{?osg}
 rm -rf $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider
 rm -f $RPM_BUILD_ROOT%{_sysconfdir}/condor/config.d/50-ce-bdii-defaults.conf

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -177,7 +177,7 @@ Conflicts: %{name}
 %setup -q
 
 %build
-%cmake -DHTCONDORCE_VERSION=%{version} -DSTATE_INSTALL_DIR=%{_localstatedir} -DCMAKE_INSTALL_LIBDIR=%{_libdir}  -DPYTHON_SITELIB=%{python_sitelib}
+%cmake -DHTCONDORCE_VERSION=%{version} -DSTATE_INSTALL_DIR=%{_localstatedir} -DPYTHON_SITELIB=%{python_sitelib}
 make %{?_smp_mflags}
 
 %install

--- a/src/condor_ce_startup
+++ b/src/condor_ce_startup
@@ -4,12 +4,18 @@ fail() {
     RETVAL="$1"
     MSG="$2"
     echo
-    echo "ERROR: $MSG"
+    echo -e "ERROR: $MSG"
     exit $RETVAL
 }
 
 # Source condor-ce environment
 [ -f /usr/share/condor-ce/condor_ce_env_bootstrap ] && . /usr/share/condor-ce/condor_ce_env_bootstrap
+
+# Verify that required dirs are owned by condor:condor (SOFTWARE-2806``)
+required_dirs="/var/run/condor-ce /var/log/condor-ce /var/log/condor-ce/user /var/lib/condor-ce /var/lib/condor-ce/spool
+/var/lib/condor-ce/execute /var/lock/condor-ce /var/lock/condor-ce/user"
+bad_dirs=$(stat --format "%n (%U:%G)" $required_dirs | awk '$2 != "(condor:condor)" {print $0}')
+[ -z "$bad_dirs" ] || fail 1 "The following directories are not owned by the condor user/group:\n$bad_dirs"
 
 # Skip sanity checks if running as a central collector
 if [ "$1" != "collector" ]; then


### PR DESCRIPTION
This solution is currently incomplete as the `chown` via CMake doesn't work because of a non-existent condor user. I think this is better handled downstream via rpm/debian packaging. Do we still want to do the ownership verification via `condor_ce_startup`?

https://jira.opensciencegrid.org/browse/SOFTWARE-2806