### PR TITLE
CEView daemon doesn't have permission to send keepalive to CE Master

### DIFF
--- a/config/05-ce-view-defaults.conf
+++ b/config/05-ce-view-defaults.conf
@@ -39,8 +39,18 @@ SCHEDD_CRON_CEVIEW_KILL = True
 SCHEDD_CRON_CEVIEW_PREFIX = CEView
 SCHEDD_CRON_CEVIEW_RECONFIG_RERUN = True
 
-# Do not do security negotiation; this can break CE View when using IP-load-balanced collectors.
-CEVIEW.SEC_CLIENT_NEGOTIATION = NEVER
+if defined MYOSG_HOST
+    # Do not do security negotiation; this can break CE View when using IP-load-balanced collectors.
+    CEVIEW.SEC_CLIENT_NEGOTIATION = NEVER
+else
+    # Default negotiation in 8.6 is PREFERRED, so the CE View also needs
+    # PREFERRED negotiation to send DC_CHILDALIVE (SOFTWARE-2820)
+    CEVIEW.SEC_CLIENT_NEGOTIATION = PREFERRED
+    # CE View drops privs after startup to the condor user, which doesn't
+    # have access to the host key for auth. Use FS auth instead.
+    CEVIEW.SEC_CLIENT_AUTHENTICATION_METHODS = FS
+    MASTER.SEC_DEFAULT_AUTHENTICATION_METHODS = FS, GSI
+endif
 
 # Cherrypy does not respect SIGTERM signals from the master, so kill it (and everything else) quickly
 # with SIGKILL signal (9) after waiting 10 seconds

--- a/config/05-ce-view.conf
+++ b/config/05-ce-view.conf
@@ -23,10 +23,3 @@ HTCONDORCE_VIEW_PORT = 80
 # it monitor a different one, uncomment the line below:
 
 # HTCONDORCE_VIEW_POOL=ce.example.com
-
-# By default, CEView won't authenticate with the pool; this is to prevent
-# invalid security sessions from breaking queries.
-# However, there may be some cases where this is needed:
-# CEVIEW.SEC_CLIENT_NEGOTIATION = OPTIONAL
-# NOTE: Unless you significantly changed the security configuration of your CE,
-# you don't need this.


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2820

### Symptom

Users were seeing their CE Views getting killed after 24 hours (the security session default lifetime) 

### Cause

Since the CE View starts up as root, it has access to the hostkey so it could send keepalives until the initial security session died. After it tries to get a new security session, it's running as the 'condor' user so it can't access the hostkey, can't send keepalives, and the master kills it. 

### Solution

Prefer FS auth over GSI for the master and only auth the CE View via FS. We don't fix this for the central collector because the OSG cc uses IP load balancing and certs with SANs, which don't work in HTCondor for auth (https://htcondor-wiki.cs.wisc.edu/index.cgi/tktview?tn=6135,86).