### PR TITLE
Handle missing 'MyTpe' attr in 8.7.5

### DIFF
--- a/config/htcondor-ce.spec
+++ b/config/htcondor-ce.spec
@@ -2,7 +2,7 @@
 #define gitrev osg
 
 Name: htcondor-ce
-Version: 3.0.3
+Version: 3.0.4
 Release: 1%{?gitrev:.%{gitrev}git}%{?dist}
 Summary: A framework to run HTCondor as a CE
 BuildArch: noarch
@@ -491,6 +491,9 @@ fi
 %attr(1777,root,root) %dir %{_localstatedir}/lib/gratia/condorce_data
 
 %changelog
+* Fri Dec 08 2017 Brian Lin <blin@cs.wisc.edu> - 3.0.4-1
+- Handle missing 'MyType' attribute in condor 8.7.5
+
 * Wed Dec 06 2017 Brian Lin <blin@cs.wisc.edu> - 3.0.3-1
 - Fix condor_ce_ping with IPv6 addresses (SOFTWARE-3030)
 - Fix for CEView being killed after 24h (SOFTWARE-2820)

--- a/src/condor_ce_trace
+++ b/src/condor_ce_trace
@@ -115,11 +115,10 @@ def parse_opts():
 
 def check_authz(collector_ad, schedd_ad=None):
     print "Testing HTCondor-CE authorization..."
-    ping_args = [(collector_ad, 'READ'),
-                 (schedd_ad, 'WRITE')]
+    ping_args = [(collector_ad, 'READ', 'collector'),
+                 (schedd_ad, 'WRITE', 'scheduler')]
 
-    for daemon_ad, cmd in ping_args:
-        dtype = daemon_ad['MyType'].lower()
+    for daemon_ad, cmd, dtype in ping_args:
         addr = daemon_ad['MyAddress']
         try:
             ping_ad = htcondor.SecMan().ping(daemon_ad, cmd)

--- a/src/condor_ce_trace
+++ b/src/condor_ce_trace
@@ -113,7 +113,7 @@ def parse_opts():
     return opts, args
 
 
-def check_authz(collector_ad, schedd_ad=None):
+def check_authz(collector_ad, schedd_ad):
     print "Testing HTCondor-CE authorization..."
     ping_args = [(collector_ad, 'READ', 'collector'),
                  (schedd_ad, 'WRITE', 'scheduler')]


### PR DESCRIPTION
http://condor-wiki.cs.wisc.edu/index.cgi/tktview?tn=6502

This caused `condor_ce_trace` to fail with 8.7.5