### PR TITLE
require voms-clients-cpp explicitly (SOFTWARE-3201)

### DIFF
--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -151,7 +151,7 @@ Summary: Client-side tools for submission to HTCondor-CE
 # Point is to be able to submit jobs without installing the server.
 Requires: condor
 # voms-proxy-info used by condor_ce_trace
-Requires: /usr/bin/voms-proxy-info
+Requires: voms-clients-cpp
 %if ! 0%{?uw_build}
 Requires: grid-certificates >= 7
 %endif


### PR DESCRIPTION
The requirement for /usr/bin/voms-proxy-info can be satisfied by
either voms-clients-cpp or voms-clients-java, the latter of which
is now problematic for osg-3.3.  So, we'll just be explicit now
about which package to bring in.