### PR TITLE
Remove regex from replace

### DIFF
--- a/contrib/bdii/htcondor-ce-provider
+++ b/contrib/bdii/htcondor-ce-provider
@@ -203,7 +203,7 @@ def main():
         cmd = ['/usr/bin/openssl', 'x509', '-noout', '-issuer', '-nameopt', 'RFC2253', '-in',
                '/etc/grid-security/hostcert.pem']
         cp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        issuer = cp.communicate()[0].replace(r'issuer=\s*', '').strip()
+        issuer = cp.communicate()[0].replace('issuer=', '').strip()
 
         name = ce_schedd_ad['Name']
         start_time = datetime.fromtimestamp(int(ce_schedd_ad['DaemonStartTime'])).strftime('%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
This is not required as it is handled by strip()