### PR TITLE
Revert the default condor_q behavior to query all users' jobs

### DIFF
--- a/config/01-common-auth-defaults.conf
+++ b/config/01-common-auth-defaults.conf
@@ -34,3 +34,7 @@ CERTIFICATE_MAPFILE=/etc/condor-ce/condor_mapfile
 # these may no longer work with the latest OpenSSL on RHEL6.
 GSI_DELEGATION_KEYBITS = 1024
 
+# The new condor_q behavior forces an authZ check, which we explicitly set as
+# optional above.
+# This allows unauthorized users to query the schedd
+CONDOR_Q_ONLY_MY_JOBS = false

--- a/config/condor_config
+++ b/config/condor_config
@@ -70,12 +70,6 @@ VM_GAHP_SERVER = $(SBIN)/condor_vm-gahp
 DATA_DIR = $(RELEASE_DIR)/share/condor-ce
 USER_JOB_WRAPPER = $(DATA_DIR)/local-wrapper
 
-# Force condor_ce_q to show jobs for all users until 'root' is recognized as
-# a QUEUE_SUPER_USER when using a CERTIFICATE_MAPFILE
-:if version < 8.5.6
-CONDOR_Q_ONLY_MY_JOBS = False
-:endif
-
 # Disable mail on service restart
 SCHEDD_RESTART_REPORT=
 


### PR DESCRIPTION
The new condor_q behavior requires an authZ check and that can cause
failures when running condor_ce_q. We don't care who can query the CE
schedd so this isn't a security issue.