### PR TITLE
Adding default memory to queue information

### DIFF
--- a/src/htcondorce/web_utils.py
+++ b/src/htcondorce/web_utils.py
@@ -127,7 +127,7 @@ def generate_queue_ad(resource_catalog, ce):
                          'entry': entry.get('Name', ''),
                          'name': queue,
                          'status': 'Production',
-                         'memory': int(entry.get('Memory')),
+                         'memory': int(entry.get('Memory', 0)),
                          'cpus': int(entry.get('CPUs', 1)),
                          'votag': entry.get('VOTag', ''),
                          'subclusters': entry.get('Subclusters', [])


### PR DESCRIPTION
This failed for sites which did not set memory in the
resource catalog.