### PR TITLE
Revert "Update the central collector via TCP (SOFTWARE-3668)"

### DIFF
--- a/config/05-ce-view-defaults.conf
+++ b/config/05-ce-view-defaults.conf
@@ -59,9 +59,4 @@ SHUTDOWN_FAST_TIMEOUT = 10
 # Run the CE View as a DC daemon.
 DC_DAEMON_LIST = +CEVIEW
 
-# Improve consistency of central collector updates
-# Prior to 8.9.2, these updates blocked
-# https://htcondor-wiki.cs.wisc.edu/index.cgi/tktview?tn=6249
-if version >= 8.9.2
-  UPDATE_VIEW_COLLECTOR_WITH_TCP = True
-endif
+


### PR DESCRIPTION
This reverts commit 765f8a8cc4736f12e5c58bab3e2d2411a4812665.

@matyasselmeci whelp, @timtheisen pointed out that this actually hasn't been addressed in HTCondor yet so I'm reverting it