### PR TITLE
Exclude jobs with undefined or zero RemoteWallClockTime

### DIFF
--- a/contrib/apelscripts/condor_batch.sh
+++ b/contrib/apelscripts/condor_batch.sh
@@ -23,7 +23,7 @@ OUTPUT_FILE="$OUTPUT_DIR/batch-$(date -u --date='yesterday' +%Y%m%d )-$(hostname
 [[ -d $OUTPUT_DIR && -w $OUTPUT_DIR ]] || fail "Cannot write to $OUTPUT_DIR"
 
 # Build the filter for the history command
-CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && !isUndefined(RemoteWallClockTime) && RemoteWallClockTime =!= 0.0 "
+CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallClockTime != 0 "
 
 HISTORY_EXTRA_ARGS=(-format "\n" EMPTY)
 safe_config_val SCALING_ATTR APEL_SCALING_ATTR

--- a/contrib/apelscripts/condor_blah.sh
+++ b/contrib/apelscripts/condor_blah.sh
@@ -27,7 +27,7 @@ if [ ! -d $OUTPUT_DIR ] || [ ! -w $OUTPUT_DIR ]; then
 fi
 
 # Build the filter for the history command
-CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && !isUndefined(RemoteWallClockTime) && RemoteWallClockTime =!= 0.0 "
+CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallClockTime != 0 "
 
 safe_config_val CE_HOST APEL_CE_HOST
 safe_config_val BATCH_HOST APEL_BATCH_HOST


### PR DESCRIPTION
Cherry-picked from #271 