### PR TITLE
Add back-to-top button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
   features:
     - navigation.tabs  # Split top-level nav items into their own menu at the top of the pages
     - toc.integrate    # integrate the table of contents into the left nav
+    - navigation.top   # adds back-to-top button that appears when scrolling up
 
 extra_css:
   - css/superfences.css


### PR DESCRIPTION
Nice for long documents; appears when scrolling back up

Same as https://github.com/opensciencegrid/docs/pull/897